### PR TITLE
feat: adding new forth color (blue) option

### DIFF
--- a/badge.go
+++ b/badge.go
@@ -34,3 +34,14 @@ func (m *Markdown) GreenBadge(text string) *Markdown {
 func (m *Markdown) GreenBadgef(format string, args ...interface{}) *Markdown {
 	return m.GreenBadge(fmt.Sprintf(format, args...))
 }
+
+// BlueBadge set text with blue badge format.
+func (m *Markdown) blueBadge(text string) *Markdown {
+    m.body = append(m.body, fmt.Sprintf("![Badge](https://img.shields.io/badge/%s-blue)", text))
+    return m
+}
+
+// BlueBadgef set text with blue badge format. It is similar to fmt.Sprintf.
+func (m *Markdown) BlueBadgef(format string, args ...interface{}) *Markdown {
+    return m.blueBadge(fmt.Sprintf(format, args...))
+}

--- a/badge_test.go
+++ b/badge_test.go
@@ -47,4 +47,17 @@ func TestMarkdown_RedBadgef(t *testing.T) {
 			t.Errorf("value is mismatch (-want +got):\n%s", diff)
 		}
 	})
+
+	t.Run("success BlueBadgef()", func(t *testing.T) {
+		t.Parallel()
+	
+		m := NewMarkdown(io.Discard)
+		m.BlueBadgef("%s", "Hello")
+		want := []string{"![Badge](https://img.shields.io/badge/Hello-blue)"}
+		got := m.body
+	
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("value is mismatch (-want +got):\n%s", diff)
+		}
+	})
 }


### PR DESCRIPTION
I guess we needed new color, I met a situation where I needed new color option

Let us say
red: failed deployment
yellow: deploying
green: deployed
blue: undeployed (new color)

I bilieve the third color would be able to fit  other scenarios  which must not necessary  be in error,warning,sucess color scheme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced blue badge formatting in markdown text.
  
- **Tests**
  - Added a test case to ensure the correct functionality of the blue badge formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->