### PR TITLE
fix: honour table alignment, guard nil writers, and anchor the toc indent

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -391,7 +391,19 @@ func (m *Markdown) generateTableOfContents() []string {
 	}
 
 	tocLines := make([]string, 0, len(m.headers))
-	minIndent := int(m.tocOptions.MinDepth)
+	// Indent relative to the shallowest heading that actually appears, not to
+	// the requested MinDepth. TableOfContents pins MinDepth at H1, so a document
+	// that starts at H2 would otherwise have every entry indented two spaces,
+	// producing a list nested under nothing.
+	minIndent := int(m.tocOptions.MaxDepth)
+	for _, header := range m.headers {
+		if header.level < m.tocOptions.MinDepth || header.level > m.tocOptions.MaxDepth {
+			continue
+		}
+		if int(header.level) < minIndent {
+			minIndent = int(header.level)
+		}
+	}
 	anchorCounts := make(map[string]int, len(m.headers))
 
 	for _, header := range m.headers {
@@ -698,8 +710,86 @@ func (m *Markdown) CustomTable(t TableSet, options TableOptions) *Markdown {
 		return m
 	}
 
-	m.body = append(m.body, buf.String())
+	m.body = append(m.body, applyAlignmentToDelimiterRow(buf.String(), t.Alignment))
 	return m
+}
+
+// applyAlignmentToDelimiterRow rewrites the delimiter row of a rendered table so
+// it carries the alignment colons markdown uses.
+//
+// tablewriter aligns by padding cells, which says nothing to a markdown reader:
+// alignment lives in the second row, as :--- / :---: / ---:. Without this,
+// TableSet.Alignment is silently dropped by CustomTable while Table honours it.
+// Each column keeps its rendered width so the source stays visually aligned.
+func applyAlignmentToDelimiterRow(rendered string, alignment []TableAlignment) string {
+	if len(alignment) == 0 {
+		return rendered
+	}
+
+	lineFeed := internal.LineFeed()
+	lines := strings.Split(rendered, lineFeed)
+	const delimiterRowIndex = 1
+	if len(lines) <= delimiterRowIndex {
+		return rendered
+	}
+
+	// The delimiter row is "|-----|------|"; splitting on "|" yields an empty
+	// field at each end.
+	// Splitting "|---|---|" on "|" leaves an empty field at each end, so a real
+	// delimiter row always yields at least two fields.
+	const minDelimiterFields = 2
+	columns := strings.Split(lines[delimiterRowIndex], "|")
+	if len(columns) < minDelimiterFields {
+		return rendered
+	}
+
+	for i := 1; i < len(columns)-1; i++ {
+		if strings.TrimLeft(columns[i], "-") != "" {
+			return rendered // not a delimiter row after all; leave it alone
+		}
+		align := AlignDefault
+		if i-1 < len(alignment) {
+			align = alignment[i-1]
+		}
+		columns[i] = delimiterCell(len(columns[i]), align)
+	}
+
+	lines[delimiterRowIndex] = strings.Join(columns, "|")
+	return strings.Join(lines, lineFeed)
+}
+
+const (
+	// oneSidedMarkerWidth is the narrowest cell that fits ":-" or "-:".
+	oneSidedMarkerWidth = 2
+	// twoSidedMarkerWidth is the narrowest cell that fits ":-:".
+	twoSidedMarkerWidth = 3
+)
+
+// delimiterCell renders one delimiter cell of the given width for the alignment.
+// The width is preserved so the rendered table keeps its columns lined up. A
+// column too narrow to hold its marker falls back to a plain rule rather than
+// widening the table.
+func delimiterCell(width int, align TableAlignment) string {
+	switch align {
+	case AlignLeft:
+		if width < oneSidedMarkerWidth {
+			return strings.Repeat("-", width)
+		}
+		return ":" + strings.Repeat("-", width-1)
+	case AlignRight:
+		if width < oneSidedMarkerWidth {
+			return strings.Repeat("-", width)
+		}
+		return strings.Repeat("-", width-1) + ":"
+	case AlignCenter:
+		if width < twoSidedMarkerWidth {
+			return strings.Repeat("-", width)
+		}
+		return ":" + strings.Repeat("-", width-twoSidedMarkerWidth+1) + ":"
+	case AlignDefault:
+		return strings.Repeat("-", width)
+	}
+	return strings.Repeat("-", width)
 }
 
 // LF is line feed.

--- a/mermaid/arch/architecture.go
+++ b/mermaid/arch/architecture.go
@@ -4,6 +4,7 @@
 package arch
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -45,6 +46,13 @@ func (a *Architecture) String() string {
 
 // Build writes the architecture diagram body to the output destination.
 func (a *Architecture) Build() error {
+	if a.dest == nil {
+		if a.err == nil {
+			a.err = errors.New("output writer must not be nil")
+		}
+		return a.err
+	}
+
 	if _, err := a.dest.Write([]byte(a.String())); err != nil {
 		if a.err != nil {
 			return fmt.Errorf("failed to write: %w: %s", err, a.err.Error()) //nolint:wrapcheck

--- a/mermaid/arch/nil_writer_test.go
+++ b/mermaid/arch/nil_writer_test.go
@@ -1,0 +1,33 @@
+package arch_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/arch"
+)
+
+// TestBuildWithNilWriter covers the case where a architecture is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := arch.NewArchitecture(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/class/class_diagram.go
+++ b/mermaid/class/class_diagram.go
@@ -4,6 +4,7 @@
 package class
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -58,6 +59,13 @@ func (d *Diagram) Error() error {
 
 // Build writes the class diagram body to the output destination.
 func (d *Diagram) Build() error {
+	if d.dest == nil {
+		if d.err == nil {
+			d.err = errors.New("output writer must not be nil")
+		}
+		return d.err
+	}
+
 	if _, err := fmt.Fprint(d.dest, d.String()); err != nil {
 		d.err = fmt.Errorf("failed to write: %w", err)
 		return d.err

--- a/mermaid/class/nil_writer_test.go
+++ b/mermaid/class/nil_writer_test.go
@@ -1,0 +1,33 @@
+package class_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/class"
+)
+
+// TestBuildWithNilWriter covers the case where a diagram is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := class.NewDiagram(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/er/entity_relationship.go
+++ b/mermaid/er/entity_relationship.go
@@ -2,6 +2,7 @@
 package er
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -68,6 +69,13 @@ func (d *Diagram) String() string {
 
 // Build writes the entity relationship body to the output destination.
 func (d *Diagram) Build() error {
+	if d.dest == nil {
+		if d.err == nil {
+			d.err = errors.New("output writer must not be nil")
+		}
+		return d.err
+	}
+
 	if _, err := fmt.Fprint(d.dest, d.String()); err != nil {
 		if d.err != nil {
 			return fmt.Errorf("failed to write: %w: %s", err, d.err.Error()) //nolint:wrapcheck

--- a/mermaid/er/nil_writer_test.go
+++ b/mermaid/er/nil_writer_test.go
@@ -1,0 +1,33 @@
+package er_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/er"
+)
+
+// TestBuildWithNilWriter covers the case where a diagram is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := er.NewDiagram(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/flowchart/flowchart.go
+++ b/mermaid/flowchart/flowchart.go
@@ -2,6 +2,7 @@
 package flowchart
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -51,6 +52,13 @@ func (f *Flowchart) String() string {
 
 // Build writes the flowchart body to the output destination.
 func (f *Flowchart) Build() error {
+	if f.dest == nil {
+		if f.err == nil {
+			f.err = errors.New("output writer must not be nil")
+		}
+		return f.err
+	}
+
 	if _, err := fmt.Fprint(f.dest, f.String()); err != nil {
 		if f.err != nil {
 			return fmt.Errorf("failed to write: %w: %s", err, f.err.Error()) //nolint:wrapcheck

--- a/mermaid/flowchart/nil_writer_test.go
+++ b/mermaid/flowchart/nil_writer_test.go
@@ -1,0 +1,33 @@
+package flowchart_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/flowchart"
+)
+
+// TestBuildWithNilWriter covers the case where a flowchart is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := flowchart.NewFlowchart(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/gantt/gantt_chart.go
+++ b/mermaid/gantt/gantt_chart.go
@@ -2,6 +2,7 @@
 package gantt
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -68,6 +69,13 @@ func (c *Chart) Error() error {
 
 // Build writes the Gantt chart body to the output destination.
 func (c *Chart) Build() error {
+	if c.dest == nil {
+		if c.err == nil {
+			c.err = errors.New("output writer must not be nil")
+		}
+		return c.err
+	}
+
 	if _, err := fmt.Fprint(c.dest, c.String()); err != nil {
 		if c.err != nil {
 			return fmt.Errorf("failed to write: %w: %s", err, c.err.Error()) //nolint:wrapcheck

--- a/mermaid/gantt/nil_writer_test.go
+++ b/mermaid/gantt/nil_writer_test.go
@@ -1,0 +1,33 @@
+package gantt_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/gantt"
+)
+
+// TestBuildWithNilWriter covers the case where a chart is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := gantt.NewChart(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/gitgraph/git_graph.go
+++ b/mermaid/gitgraph/git_graph.go
@@ -77,6 +77,13 @@ func (d *Diagram) Error() error {
 
 // Build writes the git graph diagram body to the output destination.
 func (d *Diagram) Build() error {
+	if d.dest == nil {
+		if d.err == nil {
+			d.err = errors.New("output writer must not be nil")
+		}
+		return d.err
+	}
+
 	if d.err != nil {
 		return d.err
 	}

--- a/mermaid/gitgraph/nil_writer_test.go
+++ b/mermaid/gitgraph/nil_writer_test.go
@@ -1,0 +1,33 @@
+package gitgraph_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/gitgraph"
+)
+
+// TestBuildWithNilWriter covers the case where a diagram is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := gitgraph.NewDiagram(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/mindmap/mindmap.go
+++ b/mermaid/mindmap/mindmap.go
@@ -74,6 +74,13 @@ func (d *Diagram) Error() error {
 
 // Build writes the mindmap diagram body to the output destination.
 func (d *Diagram) Build() error {
+	if d.dest == nil {
+		if d.err == nil {
+			d.err = errors.New("output writer must not be nil")
+		}
+		return d.err
+	}
+
 	if d.err != nil {
 		return d.err
 	}

--- a/mermaid/mindmap/nil_writer_test.go
+++ b/mermaid/mindmap/nil_writer_test.go
@@ -1,0 +1,33 @@
+package mindmap_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/mindmap"
+)
+
+// TestBuildWithNilWriter covers the case where a diagram is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := mindmap.NewDiagram(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/piechart/nil_writer_test.go
+++ b/mermaid/piechart/nil_writer_test.go
@@ -1,0 +1,33 @@
+package piechart_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/piechart"
+)
+
+// TestBuildWithNilWriter covers the case where a pie chart is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := piechart.NewPieChart(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/piechart/pie_chart.go
+++ b/mermaid/piechart/pie_chart.go
@@ -2,6 +2,7 @@
 package piechart
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -63,6 +64,13 @@ func (p *PieChart) String() string {
 
 // Build writes the pie chart body to the output destination.
 func (p *PieChart) Build() error {
+	if p.dest == nil {
+		if p.err == nil {
+			p.err = errors.New("output writer must not be nil")
+		}
+		return p.err
+	}
+
 	if _, err := fmt.Fprint(p.dest, p.String()); err != nil {
 		if p.err != nil {
 			return fmt.Errorf("failed to write: %w: %s", err, p.err.Error()) //nolint:wrapcheck

--- a/mermaid/quadrant/nil_writer_test.go
+++ b/mermaid/quadrant/nil_writer_test.go
@@ -1,0 +1,33 @@
+package quadrant_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/quadrant"
+)
+
+// TestBuildWithNilWriter covers the case where a chart is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := quadrant.NewChart(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/quadrant/quadrant_chart.go
+++ b/mermaid/quadrant/quadrant_chart.go
@@ -2,6 +2,7 @@
 package quadrant
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -53,6 +54,13 @@ func (ch *Chart) Error() error {
 
 // Build writes the quadrant chart body to the output destination.
 func (ch *Chart) Build() error {
+	if ch.dest == nil {
+		if ch.err == nil {
+			ch.err = errors.New("output writer must not be nil")
+		}
+		return ch.err
+	}
+
 	if _, err := fmt.Fprint(ch.dest, ch.String()); err != nil {
 		if ch.err != nil {
 			return fmt.Errorf("failed to write: %w: %s", err, ch.err.Error()) //nolint:wrapcheck

--- a/mermaid/requirement/nil_writer_test.go
+++ b/mermaid/requirement/nil_writer_test.go
@@ -1,0 +1,33 @@
+package requirement_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/requirement"
+)
+
+// TestBuildWithNilWriter covers the case where a diagram is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := requirement.NewDiagram(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/requirement/requirement_diagram.go
+++ b/mermaid/requirement/requirement_diagram.go
@@ -148,6 +148,13 @@ func (d *Diagram) Error() error {
 
 // Build writes the requirement diagram body to the output destination.
 func (d *Diagram) Build() error {
+	if d.dest == nil {
+		if d.err == nil {
+			d.err = errors.New("output writer must not be nil")
+		}
+		return d.err
+	}
+
 	if d.err != nil {
 		return d.err
 	}

--- a/mermaid/sequence/nil_writer_test.go
+++ b/mermaid/sequence/nil_writer_test.go
@@ -1,0 +1,33 @@
+package sequence_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/sequence"
+)
+
+// TestBuildWithNilWriter covers the case where a diagram is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := sequence.NewDiagram(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/sequence/sequence.go
+++ b/mermaid/sequence/sequence.go
@@ -2,6 +2,7 @@
 package sequence
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -49,6 +50,13 @@ func (d *Diagram) Error() error {
 
 // Build writes the sequence diagram body to the output destination.
 func (d *Diagram) Build() error {
+	if d.dest == nil {
+		if d.err == nil {
+			d.err = errors.New("output writer must not be nil")
+		}
+		return d.err
+	}
+
 	if _, err := fmt.Fprint(d.dest, d.String()); err != nil {
 		if d.err != nil {
 			return fmt.Errorf("failed to write: %w: %s", err, d.err.Error()) //nolint:wrapcheck

--- a/mermaid/state/nil_writer_test.go
+++ b/mermaid/state/nil_writer_test.go
@@ -1,0 +1,33 @@
+package state_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/state"
+)
+
+// TestBuildWithNilWriter covers the case where a diagram is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := state.NewDiagram(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/state/state_diagram.go
+++ b/mermaid/state/state_diagram.go
@@ -2,6 +2,7 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -56,6 +57,13 @@ func (d *Diagram) Error() error {
 
 // Build writes the state diagram body to the output destination.
 func (d *Diagram) Build() error {
+	if d.dest == nil {
+		if d.err == nil {
+			d.err = errors.New("output writer must not be nil")
+		}
+		return d.err
+	}
+
 	if _, err := fmt.Fprint(d.dest, d.String()); err != nil {
 		if d.err != nil {
 			return fmt.Errorf("failed to write: %w: %s", err, d.err.Error()) //nolint:wrapcheck

--- a/mermaid/userjourney/nil_writer_test.go
+++ b/mermaid/userjourney/nil_writer_test.go
@@ -1,0 +1,33 @@
+package userjourney_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/userjourney"
+)
+
+// TestBuildWithNilWriter covers the case where a diagram is built for String()
+// only and Build() is called by mistake. Build() used to dereference the nil
+// writer and take the process down; it has to return an error instead.
+func TestBuildWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Build() panicked with a nil writer: %v", r)
+		}
+	}()
+
+	d := userjourney.NewDiagram(nil)
+
+	// String() has always worked without a writer, and callers rely on it.
+	_ = d.String()
+
+	err := d.Build()
+	if err == nil {
+		t.Fatal("Build() with a nil writer must return an error")
+	}
+	if err.Error() != "output writer must not be nil" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/mermaid/userjourney/user_journey.go
+++ b/mermaid/userjourney/user_journey.go
@@ -73,6 +73,13 @@ func (d *Diagram) Error() error {
 
 // Build writes the user journey diagram body to the output destination.
 func (d *Diagram) Build() error {
+	if d.dest == nil {
+		if d.err == nil {
+			d.err = errors.New("output writer must not be nil")
+		}
+		return d.err
+	}
+
 	if d.err != nil {
 		return d.err
 	}

--- a/table_alignment_test.go
+++ b/table_alignment_test.go
@@ -1,0 +1,201 @@
+package markdown
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/nao1215/markdown/internal"
+)
+
+// delimiterRow returns the alignment row of the first table in the rendered
+// document, which is where markdown records column alignment.
+func delimiterRow(t *testing.T, rendered string) string {
+	t.Helper()
+
+	lines := strings.Split(rendered, internal.LineFeed())
+	if len(lines) < 2 {
+		t.Fatalf("rendered table has %d line(s), want at least 2:\n%s", len(lines), rendered)
+	}
+	return lines[1]
+}
+
+// TestCustomTableHonoursAlignment pins the behaviour that CustomTable used to
+// drop on the floor: TableSet.Alignment is a documented public field, but it
+// never reached the rendered output, so choosing CustomTable silently cost you
+// alignment.
+func TestCustomTableHonoursAlignment(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		alignment []TableAlignment
+		want      string
+	}{
+		"left, centre, right": {
+			alignment: []TableAlignment{AlignLeft, AlignCenter, AlignRight},
+			want:      "|:----|:------:|-----:|",
+		},
+		"default keeps a plain rule": {
+			alignment: []TableAlignment{AlignDefault, AlignDefault, AlignDefault},
+			want:      "|-----|--------|------|",
+		},
+		"shorter than the header falls back to default": {
+			alignment: []TableAlignment{AlignRight},
+			want:      "|----:|--------|------|",
+		},
+		"longer than the header ignores the extra entries": {
+			alignment: []TableAlignment{AlignLeft, AlignLeft, AlignLeft, AlignRight, AlignCenter},
+			want:      "|:----|:-------|:-----|",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			if err := NewMarkdown(&buf).CustomTable(TableSet{
+				Header:    []string{"key", "middle", "last"},
+				Rows:      [][]string{{"a", "b", "c"}},
+				Alignment: tt.alignment,
+			}, TableOptions{}).Build(); err != nil {
+				t.Fatalf("failed to build: %v", err)
+			}
+
+			if got := delimiterRow(t, buf.String()); got != tt.want {
+				t.Errorf("delimiter row mismatch:\n got: %q\nwant: %q\nfull output:\n%s", got, tt.want, buf.String())
+			}
+		})
+	}
+}
+
+// TestCustomTableWithoutAlignmentIsUnchanged is the compatibility guard: a
+// TableSet with no Alignment must render exactly as it did before alignment
+// support was wired in, so existing golden files keep passing.
+func TestCustomTableWithoutAlignmentIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := NewMarkdown(&buf).CustomTable(TableSet{
+		Header: []string{"key", "middle", "last"},
+		Rows:   [][]string{{"a", "b", "c"}, {"longer", "value", "here"}},
+	}, TableOptions{}).Build(); err != nil {
+		t.Fatalf("failed to build: %v", err)
+	}
+
+	want := strings.Join([]string{
+		"|  key   | middle | last |",
+		"|--------|--------|------|",
+		"| a      | b      | c    |",
+		"| longer | value  | here |",
+		"",
+	}, internal.LineFeed())
+
+	if diff := cmp.Diff(want, buf.String()); diff != "" {
+		t.Errorf("output changed (-want +got):\n%s", diff)
+	}
+}
+
+// TestTableAndCustomTableAgreeOnAlignment keeps the two table renderers from
+// drifting apart again: whatever alignment a caller asks for, both must place
+// the colons on the same sides.
+func TestTableAndCustomTableAgreeOnAlignment(t *testing.T) {
+	t.Parallel()
+
+	set := TableSet{
+		Header:    []string{"key", "middle", "last"},
+		Rows:      [][]string{{"a", "b", "c"}},
+		Alignment: []TableAlignment{AlignRight, AlignCenter, AlignLeft},
+	}
+
+	var plain, custom bytes.Buffer
+	if err := NewMarkdown(&plain).Table(set).Build(); err != nil {
+		t.Fatalf("failed to build Table: %v", err)
+	}
+	if err := NewMarkdown(&custom).CustomTable(set, TableOptions{}).Build(); err != nil {
+		t.Fatalf("failed to build CustomTable: %v", err)
+	}
+
+	sides := func(row string) []string {
+		cells := strings.Split(strings.Trim(row, "|"), "|")
+		out := make([]string, 0, len(cells))
+		for _, cell := range cells {
+			switch {
+			case strings.HasPrefix(cell, ":") && strings.HasSuffix(cell, ":"):
+				out = append(out, "center")
+			case strings.HasPrefix(cell, ":"):
+				out = append(out, "left")
+			case strings.HasSuffix(cell, ":"):
+				out = append(out, "right")
+			default:
+				out = append(out, "default")
+			}
+		}
+		return out
+	}
+
+	if diff := cmp.Diff(sides(delimiterRow(t, plain.String())), sides(delimiterRow(t, custom.String()))); diff != "" {
+		t.Errorf("Table and CustomTable disagree on alignment (-Table +CustomTable):\n%s", diff)
+	}
+}
+
+// TestDelimiterCell covers the widths where a marker does not fit, which the
+// table renderers can reach for a very narrow column.
+func TestDelimiterCell(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		width int
+		align TableAlignment
+		want  string
+	}{
+		"left needs two characters":    {width: 1, align: AlignLeft, want: "-"},
+		"left at the minimum":          {width: 2, align: AlignLeft, want: ":-"},
+		"right needs two characters":   {width: 1, align: AlignRight, want: "-"},
+		"right at the minimum":         {width: 2, align: AlignRight, want: "-:"},
+		"centre needs three":           {width: 2, align: AlignCenter, want: "--"},
+		"centre at the minimum":        {width: 3, align: AlignCenter, want: ":-:"},
+		"default is always all dashes": {width: 4, align: AlignDefault, want: "----"},
+		"zero width":                   {width: 0, align: AlignCenter, want: ""},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := delimiterCell(tt.width, tt.align); got != tt.want {
+				t.Errorf("delimiterCell(%d, %v) = %q, want %q", tt.width, tt.align, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestApplyAlignmentToDelimiterRowLeavesOddInputAlone makes sure the rewrite
+// never corrupts something that is not a delimiter row.
+func TestApplyAlignmentToDelimiterRowLeavesOddInputAlone(t *testing.T) {
+	t.Parallel()
+
+	alignment := []TableAlignment{AlignCenter}
+
+	tests := map[string]string{
+		"no alignment requested":    "| a |" + internal.LineFeed() + "|---|",
+		"single line":               "| a |",
+		"second line is not a rule": "| a |" + internal.LineFeed() + "| b |",
+		"empty":                     "",
+	}
+
+	for name, rendered := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			use := alignment
+			if name == "no alignment requested" {
+				use = nil
+			}
+			if got := applyAlignmentToDelimiterRow(rendered, use); got != rendered {
+				t.Errorf("input was rewritten:\n got: %q\nwant: %q", got, rendered)
+			}
+		})
+	}
+}

--- a/toc_indent_test.go
+++ b/toc_indent_test.go
@@ -1,0 +1,116 @@
+package markdown
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/nao1215/markdown/internal"
+)
+
+// tocEntries returns the lines between the table of contents markers.
+func tocEntries(t *testing.T, rendered string) []string {
+	t.Helper()
+
+	begin := strings.Index(rendered, TableOfContentsMarkerBegin)
+	end := strings.Index(rendered, TableOfContentsMarkerEnd)
+	if begin == -1 || end == -1 {
+		t.Fatalf("markers missing from output:\n%s", rendered)
+	}
+
+	body := rendered[begin+len(TableOfContentsMarkerBegin) : end]
+	entries := []string{}
+	for _, line := range strings.Split(body, internal.LineFeed()) {
+		if strings.TrimSpace(line) != "" {
+			entries = append(entries, line)
+		}
+	}
+	return entries
+}
+
+// TestTableOfContentsIndentsFromTheShallowestHeading covers the case where the
+// document has no H1. TableOfContents pins MinDepth at H1, so the indent used
+// to be measured from a level that never appears and every entry came out
+// indented under nothing.
+func TestTableOfContentsIndentsFromTheShallowestHeading(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(*Markdown) *Markdown
+		want  []string
+	}{
+		"document starting at H2": {
+			build: func(m *Markdown) *Markdown {
+				return m.TableOfContents(TableOfContentsDepthH3).H2("S1").H3("S1.1")
+			},
+			want: []string{"- [S1](#s1)", "  - [S1.1](#s11)"},
+		},
+		"document with an H1 is unchanged": {
+			build: func(m *Markdown) *Markdown {
+				return m.H1("Doc").TableOfContents(TableOfContentsDepthH3).H2("S1").H3("S1.1")
+			},
+			want: []string{"- [Doc](#doc)", "  - [S1](#s1)", "    - [S1.1](#s11)"},
+		},
+		"document starting at H3": {
+			build: func(m *Markdown) *Markdown {
+				return m.TableOfContents(TableOfContentsDepthH4).H3("Deep").H4("Deeper")
+			},
+			want: []string{"- [Deep](#deep)", "  - [Deeper](#deeper)"},
+		},
+		"shallowest heading appears late": {
+			build: func(m *Markdown) *Markdown {
+				return m.TableOfContents(TableOfContentsDepthH3).H3("First").H2("Later")
+			},
+			want: []string{"  - [First](#first)", "- [Later](#later)"},
+		},
+		"explicit range is unaffected": {
+			build: func(m *Markdown) *Markdown {
+				return m.TableOfContentsWithRange(TableOfContentsDepthH2, TableOfContentsDepthH4).
+					H2("S1").H3("S1.1")
+			},
+			want: []string{"- [S1](#s1)", "  - [S1.1](#s11)"},
+		},
+		"headings outside the range are skipped": {
+			build: func(m *Markdown) *Markdown {
+				return m.TableOfContentsWithRange(TableOfContentsDepthH2, TableOfContentsDepthH2).
+					H1("Title").H2("S1").H3("S1.1")
+			},
+			want: []string{"- [S1](#s1)"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			if err := tt.build(NewMarkdown(&buf)).Build(); err != nil {
+				t.Fatalf("failed to build: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.want, tocEntries(t, buf.String())); diff != "" {
+				t.Errorf("table of contents mismatch (-want +got):\n%s\nfull output:\n%s", diff, buf.String())
+			}
+		})
+	}
+}
+
+// TestTableOfContentsWithNoMatchingHeadings makes sure the indent baseline does
+// not misbehave when nothing falls inside the requested range.
+func TestTableOfContentsWithNoMatchingHeadings(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := NewMarkdown(&buf).
+		TableOfContentsWithRange(TableOfContentsDepthH4, TableOfContentsDepthH6).
+		H1("Title").
+		H2("Section").
+		Build(); err != nil {
+		t.Fatalf("failed to build: %v", err)
+	}
+
+	if entries := tocEntries(t, buf.String()); len(entries) != 0 {
+		t.Errorf("expected no entries, got %v", entries)
+	}
+}


### PR DESCRIPTION
## What

Three defects that produce no error and no warning, so nobody notices until the rendered page looks wrong.

**`CustomTable` dropped `TableSet.Alignment` (#99).** The field is public and documented, and `Table` has honoured it since #33/#59, so choosing `CustomTable` silently cost you alignment. Markdown records alignment in the delimiter row, not in cell padding, so the rendered row is rewritten with colons while every column keeps its width:

```
| key | middle | last |
|:----|:------:|-----:|
| a   | b      | c    |
```

**13 of 17 mermaid subpackages panicked on a nil writer (#100).** `Build()` went straight into `fmt.Fprint(d.dest, …)`. `String()` has always worked without a writer, so a caller building a diagram for its string form and then calling `Build()` by mistake took the process down. They now return the same error the four already-guarded subpackages did.

**`TableOfContents` indented every entry when the document has no H1 (#103).** The indent baseline was the requested `MinDepth`, which `TableOfContents` pins at H1. A document starting at H2 came out nested under a heading that does not exist. The baseline is now the shallowest heading actually present in range.

## Tests

- `table_alignment_test.go`: parity between `Table` and `CustomTable`, alignment slices shorter and longer than the header, and a byte-exact guard that a `TableSet` without `Alignment` renders exactly as before. `delimiterCell` is covered at the widths where a marker does not fit.
- `toc_indent_test.go`: documents rooted at H2 and H3, an unchanged H1 document, the shallowest heading appearing late, an explicit range, and a range that matches nothing.
- `nil_writer_test.go` in each of the 13 subpackages: `Build()` returns an error and does not panic, and `String()` still works without a writer.

## Downstream impact

None observable. No surveyed downstream repository sets `Alignment`, calls `TableOfContents`, or reaches the panicking path; the compatibility guard above pins the no-alignment rendering byte for byte.

Closes #99
Closes #100
Closes #103

https://claude.ai/code/session_01LL48LunC16NCDh17BU9VmG