### PR TITLE
feat: add opt-in table cell escaping and fuzz the text handling

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,42 @@
+name: Fuzz
+
+# The push and pull request test runs only exercise the seed corpus of the fuzz
+# targets. This job does real mutation fuzzing on a schedule, because the inputs
+# that break this package are arbitrary user text: a pipe in a table cell, a
+# newline in alert text, punctuation in a heading. A newly found crasher fails
+# the scheduled run and its reproducer is written under testdata/fuzz/; it never
+# blocks a pull request.
+on:
+  workflow_dispatch:
+  schedule:
+    # 03:00 UTC daily.
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - FuzzEscapeTableCell
+          - FuzzTableRowKeepsColumnCount
+          - FuzzAlertQuotesEveryLine
+          - FuzzGitHubAnchor
+          - FuzzTableOfContentsAnchorsMatchHeadings
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Fuzz ${{ matrix.target }}
+        run: go test -run='^$' -fuzz='^${{ matrix.target }}$' -fuzztime=3m .

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,162 @@
+package markdown
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+// Every defect found in the recent downstream survey was a string-handling
+// defect: a pipe in a cell dropped a column, a newline in alert text escaped the
+// callout, a heading with punctuation produced an anchor nobody checked. The
+// table-driven tests only cover the inputs someone thought of, so these targets
+// state the properties instead and let the fuzzer look for the counterexample.
+
+// FuzzEscapeTableCell asserts the two properties the escaper promises: the
+// result never contains a character that ends a cell or a row, and escaping
+// twice changes nothing.
+func FuzzEscapeTableCell(f *testing.F) {
+	for _, seed := range []string{
+		"", "plain", "a|b", "a|b|c", `a\|b`, `a\\|b`, "a\nb", "a\r\nb", "a\rb",
+		`a\`, "[Go](https://go.dev)", "**bold**", "|", "||", "\n", "\r",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, in string) {
+		got := EscapeTableCell(in)
+
+		if strings.ContainsAny(got, "\r\n") {
+			t.Errorf("EscapeTableCell(%q) = %q, which still ends the row", in, got)
+		}
+		if unescapedPipeCount(got) != 0 {
+			t.Errorf("EscapeTableCell(%q) = %q, which still ends the cell", in, got)
+		}
+		if again := EscapeTableCell(got); again != got {
+			t.Errorf("EscapeTableCell is not idempotent: %q became %q", got, again)
+		}
+	})
+}
+
+// FuzzTableRowKeepsColumnCount asserts the property the escaper exists for: for
+// any cell content, an escaped row still has exactly as many cells as the
+// header. This is the property the unescaped path violates.
+func FuzzTableRowKeepsColumnCount(f *testing.F) {
+	for _, seed := range []string{"a", "a|b", "x\ny", "|", `\|`, ""} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, cell string) {
+		out := NewMarkdown(nil).Table(TableSet{
+			Header:      []string{"one", "two"},
+			Rows:        [][]string{{cell, "second"}},
+			EscapeCells: true,
+		}).String()
+
+		lines := strings.Split(strings.TrimRight(out, internal.LineFeed()), internal.LineFeed())
+		row := lines[len(lines)-1]
+
+		// Two edges plus one separator between the cells.
+		if got := unescapedPipeCount(row); got != 3 {
+			t.Errorf("row %q built from cell %q has %d delimiters, want 3", row, cell, got)
+		}
+	})
+}
+
+// FuzzAlertQuotesEveryLine asserts that no line of an alert can escape the
+// callout, whatever the caller puts in the text.
+func FuzzAlertQuotesEveryLine(f *testing.F) {
+	for _, seed := range []string{
+		"", "one line", "first\nsecond", "intro\n- item", "a\n\nb", "a\r\nb",
+		"> already quoted", "\n", "   ", "```\ncode\n```",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, text string) {
+		out := NewMarkdown(nil).Note(text).String()
+
+		for i, line := range strings.Split(out, internal.LineFeed()) {
+			if !strings.HasPrefix(line, ">") {
+				t.Errorf("line %d of the alert is outside the callout: %q\nfull output:\n%q", i, line, out)
+			}
+		}
+	})
+}
+
+// FuzzGitHubAnchor asserts that a generated anchor holds only the characters
+// GitHub keeps, and that generating it twice gives the same answer. A heading
+// is arbitrary user text, so this is where punctuation and non-ASCII land.
+func FuzzGitHubAnchor(f *testing.F) {
+	for _, seed := range []string{
+		"", "Simple", "With Space", "punctuation!?", "`code`", "日本語の見出し",
+		"a--b", "  leading", "MiXeD CaSe", "1. numbered", "emoji 🎉",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, heading string) {
+		anchor := generateGitHubAnchor(heading)
+
+		for _, r := range anchor {
+			if r == '-' || unicode.IsLetter(r) || unicode.IsNumber(r) {
+				continue
+			}
+			t.Errorf("anchor %q from heading %q contains %q", anchor, heading, r)
+		}
+		if again := generateGitHubAnchor(heading); again != anchor {
+			t.Errorf("anchor for %q is not stable: %q then %q", heading, anchor, again)
+		}
+	})
+}
+
+// FuzzTableOfContentsAnchorsMatchHeadings asserts that every link the table of
+// contents emits points at an anchor derived from a heading in the document.
+//
+// Uniqueness is deliberately not asserted: GitHub resolves a duplicate anchor to
+// the first heading that produces it, so a document containing both "a" twice
+// and a literal "a-1" genuinely has a collision. Renaming our anchor would point
+// the link at something GitHub does not have.
+func FuzzTableOfContentsAnchorsMatchHeadings(f *testing.F) {
+	for _, seed := range []string{"", "Same", "Same|Same", "A|B|A", "a-1|a|a", "`code`|日本語"} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, joined string) {
+		headings := strings.Split(joined, "|")
+		if len(headings) > 32 { //nolint:mnd // keep the generated document small
+			headings = headings[:32]
+		}
+
+		valid := map[string]bool{}
+		m := NewMarkdown(nil).TableOfContents(TableOfContentsDepthH2)
+		for _, heading := range headings {
+			m = m.H2(heading)
+			base := generateGitHubAnchor(heading)
+			valid[base] = true
+			for i := 1; i <= len(headings); i++ {
+				valid[fmt.Sprintf("%s-%d", base, i)] = true
+			}
+		}
+
+		entries := 0
+		for _, line := range strings.Split(m.String(), internal.LineFeed()) {
+			open := strings.Index(line, "](#")
+			if open == -1 || !strings.HasSuffix(line, ")") {
+				continue
+			}
+			entries++
+			anchor := line[open+len("](#") : len(line)-1]
+			if !valid[anchor] {
+				t.Errorf("anchor %q does not come from any heading in %q", anchor, headings)
+			}
+		}
+
+		if entries != len(headings) {
+			t.Errorf("table of contents has %d entries for %d headings", entries, len(headings))
+		}
+	})
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -142,9 +142,26 @@ func FuzzTableOfContentsAnchorsMatchHeadings(f *testing.F) {
 			}
 		}
 
+		// Scan only between the markers. A heading is arbitrary text and can
+		// itself contain "](#", so scanning the whole document would pick up the
+		// heading rather than the generated link and report a false failure.
+		// The link is the last "](#" on the line for the same reason.
 		entries := 0
+		inTOC := false
 		for _, line := range strings.Split(m.String(), internal.LineFeed()) {
-			open := strings.Index(line, "](#")
+			switch line {
+			case TableOfContentsMarkerBegin:
+				inTOC = true
+				continue
+			case TableOfContentsMarkerEnd:
+				inTOC = false
+				continue
+			}
+			if !inTOC {
+				continue
+			}
+
+			open := strings.LastIndex(line, "](#")
 			if open == -1 || !strings.HasSuffix(line, ")") {
 				continue
 			}

--- a/markdown.go
+++ b/markdown.go
@@ -690,6 +690,88 @@ type TableSet struct {
 	// Alignment is column alignment for each column.
 	// If nil or shorter than header length, remaining columns use AlignDefault.
 	Alignment []TableAlignment
+	// EscapeCells runs every header and row cell through EscapeTableCell.
+	//
+	// It is off by default because cells often hold markup the caller built on
+	// purpose, with Link or Bold, and because callers who already escape their
+	// own data would end up escaping it twice. Turn it on when the cells carry
+	// arbitrary text that may contain a pipe or a newline.
+	EscapeCells bool
+}
+
+// EscapeTableCell makes text safe to place in a table cell.
+//
+// A pipe ends the cell, so a pipe in the data silently splits it in two and
+// drops the last column of the row; a newline ends the row outright. Neither
+// produces an error, and ValidateColumns cannot see either, because the row
+// still has the right length before it is serialized.
+//
+// The function is idempotent: a pipe that the caller already escaped is left
+// alone, so passing text through it twice is harmless.
+func EscapeTableCell(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			if i+1 < len(s) {
+				switch s[i+1] {
+				case '|', '\\':
+					// Keep an existing escape intact, including the character it
+					// escapes, so "\|" does not become "\\|".
+					b.WriteByte(s[i])
+					i++
+					b.WriteByte(s[i])
+					continue
+				case '\n', '\r':
+					// A backslash before a line break is a hard break. The break
+					// itself is rewritten below, so drop the backslash rather than
+					// letting it carry the line ending through untouched.
+					continue
+				}
+			}
+			b.WriteByte(s[i])
+		case '|':
+			b.WriteString(`\|`)
+		case '\r':
+			// Swallow the CR of a CRLF pair; a lone CR ends the line too.
+			if i+1 < len(s) && s[i+1] == '\n' {
+				continue
+			}
+			b.WriteString("<br>")
+		case '\n':
+			b.WriteString("<br>")
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+// escaped returns the table with every cell escaped, leaving the original
+// untouched so the caller's slices are not modified.
+func (t TableSet) escaped() TableSet {
+	header := make([]string, len(t.Header))
+	for i, cell := range t.Header {
+		header[i] = EscapeTableCell(cell)
+	}
+
+	rows := make([][]string, len(t.Rows))
+	for i, row := range t.Rows {
+		escapedRow := make([]string, len(row))
+		for j, cell := range row {
+			escapedRow[j] = EscapeTableCell(cell)
+		}
+		rows[i] = escapedRow
+	}
+
+	return TableSet{
+		Header:      header,
+		Rows:        rows,
+		Alignment:   t.Alignment,
+		EscapeCells: t.EscapeCells,
+	}
 }
 
 // ValidateColumns checks if the number of columns in the header and records match.
@@ -716,6 +798,10 @@ func (m *Markdown) Table(t TableSet) *Markdown {
 
 	if len(t.Header) == 0 {
 		return m
+	}
+
+	if t.EscapeCells {
+		t = t.escaped()
 	}
 
 	var buf strings.Builder
@@ -782,6 +868,10 @@ func (m *Markdown) CustomTable(t TableSet, options TableOptions) *Markdown {
 		} else {
 			m.err = fmt.Errorf("failed to validate columns: %w", err)
 		}
+	}
+
+	if t.EscapeCells {
+		t = t.escaped()
 	}
 
 	buf := &strings.Builder{}

--- a/table_escape_test.go
+++ b/table_escape_test.go
@@ -1,0 +1,146 @@
+package markdown
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/nao1215/markdown/internal"
+)
+
+// TestEscapeTableCell covers the characters that end a cell or a row, and the
+// idempotence the function promises.
+func TestEscapeTableCell(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		in   string
+		want string
+	}{
+		"plain text is returned unchanged":   {in: "hello", want: "hello"},
+		"empty":                              {in: "", want: ""},
+		"pipe":                               {in: "a|b", want: `a\|b`},
+		"several pipes":                      {in: "a|b|c", want: `a\|b\|c`},
+		"pipe at the edges":                  {in: "|a|", want: `\|a\|`},
+		"already escaped pipe is left alone": {in: `a\|b`, want: `a\|b`},
+		"escaped backslash then pipe":        {in: `a\\|b`, want: `a\\\|b`},
+		"newline becomes a break":            {in: "a\nb", want: "a<br>b"},
+		"carriage return and newline":        {in: "a\r\nb", want: "a<br>b"},
+		"lone carriage return":               {in: "a\rb", want: "a<br>b"},
+		"trailing backslash":                 {in: `a\`, want: `a\`},
+		"markup the caller built survives":   {in: "[Go](https://go.dev)", want: "[Go](https://go.dev)"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := EscapeTableCell(tt.in)
+			if got != tt.want {
+				t.Errorf("EscapeTableCell(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if again := EscapeTableCell(got); again != got {
+				t.Errorf("not idempotent: %q became %q", got, again)
+			}
+		})
+	}
+}
+
+// TestTableEscapeCellsKeepsColumnCount is the point of the option: an unescaped
+// pipe splits the cell in two, so GitHub renders the row with the wrong number
+// of columns and drops the last value.
+func TestTableEscapeCellsKeepsColumnCount(t *testing.T) {
+	t.Parallel()
+
+	for name, render := range map[string]func(*Markdown, TableSet) *Markdown{
+		"Table":       func(m *Markdown, ts TableSet) *Markdown { return m.Table(ts) },
+		"CustomTable": func(m *Markdown, ts TableSet) *Markdown { return m.CustomTable(ts, TableOptions{}) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			if err := render(NewMarkdown(&buf), TableSet{
+				Header:      []string{"cmd", "desc"},
+				Rows:        [][]string{{"a|b", "keeps its value"}},
+				EscapeCells: true,
+			}).Build(); err != nil {
+				t.Fatalf("failed to build: %v", err)
+			}
+
+			lines := strings.Split(strings.TrimRight(buf.String(), internal.LineFeed()), internal.LineFeed())
+			row := lines[len(lines)-1]
+			if cells := unescapedPipeCount(row); cells != 3 {
+				t.Errorf("row has %d unescaped pipes, want 3 (one per edge plus one separator): %q", cells, row)
+			}
+			if !strings.Contains(row, "keeps its value") {
+				t.Errorf("the last column was dropped: %q", row)
+			}
+		})
+	}
+}
+
+// unescapedPipeCount counts the pipes that actually delimit cells.
+func unescapedPipeCount(row string) int {
+	count := 0
+	for i := 0; i < len(row); i++ {
+		if row[i] == '\\' {
+			i++
+			continue
+		}
+		if row[i] == '|' {
+			count++
+		}
+	}
+	return count
+}
+
+// TestTableWithoutEscapeCellsIsUnchanged is the compatibility guard: the option
+// is off by default and the rendering must not move.
+func TestTableWithoutEscapeCellsIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	set := TableSet{
+		Header: []string{"cmd", "desc"},
+		Rows:   [][]string{{"a|b", "text"}},
+	}
+
+	var buf bytes.Buffer
+	if err := NewMarkdown(&buf).Table(set).Build(); err != nil {
+		t.Fatalf("failed to build: %v", err)
+	}
+
+	want := strings.Join([]string{
+		"| cmd | desc |",
+		"|---------|---------|",
+		"| a|b | text |",
+		"",
+	}, internal.LineFeed())
+
+	if diff := cmp.Diff(want, buf.String()); diff != "" {
+		t.Errorf("output changed (-want +got):\n%s", diff)
+	}
+}
+
+// TestEscapeCellsDoesNotMutateTheCallersSlices makes sure enabling the option
+// does not write back into the data the caller passed in.
+func TestEscapeCellsDoesNotMutateTheCallersSlices(t *testing.T) {
+	t.Parallel()
+
+	header := []string{"a|b"}
+	rows := [][]string{{"c|d"}}
+
+	var buf bytes.Buffer
+	if err := NewMarkdown(&buf).Table(TableSet{
+		Header:      header,
+		Rows:        rows,
+		EscapeCells: true,
+	}).Build(); err != nil {
+		t.Fatalf("failed to build: %v", err)
+	}
+
+	if header[0] != "a|b" || rows[0][0] != "c|d" {
+		t.Errorf("caller data was modified: header=%v rows=%v", header, rows)
+	}
+}


### PR DESCRIPTION
## What

**`EscapeTableCell` and `TableSet.EscapeCells` (#98).** A pipe in cell data ends the cell, so GitHub renders the row with the wrong number of columns and drops the last value; a newline ends the row outright. `ValidateColumns` cannot catch either, because the row still has the right length before serialization. EvilBit-Labs/opnDossier carries three separate escapers for this, plus a test suite for its own `splitOnUnescapedPipes`.

The option is off by default and stays off: cells frequently hold markup the caller built with `Link` or `Bold`, and callers who already escape their own data would double-escape. `EscapeTableCell` is idempotent, so passing already-escaped text through it is harmless.

**Fuzz targets and a scheduled workflow (#107).** Every defect the downstream survey turned up was a string-handling defect on input nobody thought to test, so these targets state properties instead of examples:

| target | property |
|---|---|
| `FuzzEscapeTableCell` | result never contains a cell or row terminator; escaping is idempotent |
| `FuzzTableRowKeepsColumnCount` | an escaped row always has exactly as many cells as the header |
| `FuzzAlertQuotesEveryLine` | no line of an alert can escape the callout |
| `FuzzGitHubAnchor` | anchors hold only characters GitHub keeps, and are stable |
| `FuzzTableOfContentsAnchorsMatchHeadings` | every emitted link points at an anchor derived from a heading |

`FuzzEscapeTableCell` found a bug in the first version of the escaper straight away: a backslash directly before a newline was treated as an escape pair, so the newline was copied through untouched and still ended the row. Fixed here.

The last target deliberately does not assert uniqueness. GitHub resolves a duplicate anchor to the first heading that produces it, so a document holding `a` twice alongside a literal `a-1` genuinely collides; renaming our anchor would point the link at something GitHub does not have.

The workflow runs on a daily schedule, never on a pull request, matching the shape used in nao1215/atago.

## Downstream impact

None unless a caller opts in. A `TableSet` without `EscapeCells` renders byte for byte as before, which is asserted.

Closes #98
Closes #107

https://claude.ai/code/session_01LL48LunC16NCDh17BU9VmG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional table-cell escaping to protect pipe characters and preserve line breaks in generated Markdown tables.
  * Added support for escaping standard and custom tables while preserving column counts and existing formatting.
  * Added a public utility for escaping individual table cells.

* **Tests**
  * Added coverage for table escaping, anchors, alerts, and table-of-contents links.
  * Added scheduled and on-demand fuzz testing to validate Markdown generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->