### PR TITLE
test: cover the untested builders and error paths, and measure the library

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,11 @@ jobs:
           go-version: "1"
           check-latest: true
 
+      # doc/ holds 22 sample programs whose main() is never called by a test.
+      # Counting them measures the samples, not the library.
       - name: Run tests with coverage report output
-        run: go test -cover -coverpkg=./... -coverprofile=coverage.out ./...
+        run: |
+          pkgs="$(go list ./... | grep -v '/doc/')"
+          go test -cover -coverpkg="$(echo "$pkgs" | paste -sd,)" -coverprofile=coverage.out $pkgs
 
       - uses: k1LoW/octocov-action@a167dc0dee441b7ffc45e1b862ab55ec0d87f278 # v1

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GIT_REVISION := $(shell git rev-parse HEAD)
 GO          = go
 GO_BUILD    = $(GO) build
 GO_TEST     = $(GO) test -v
+GO_LIST     = $(GO) list
 GO_TOOL     = $(GO) tool
 GO_INSTALL  = $(GO) install
 GOOS        = ""
@@ -18,7 +19,7 @@ clean: ## Clean project
 	-rm -rf $(APP) coverage.out coverage.html
 
 test: ## Start unit test for server
-	env GOOS=$(GOOS) $(GO_TEST) -cover -coverpkg=$(GO_PKGROOT) -coverprofile=coverage.out $(GO_PKGROOT)
+	env GOOS=$(GOOS) $(GO_TEST) -cover -coverpkg=$(shell $(GO_LIST) ./... | grep -v '/doc/' | paste -sd,) -coverprofile=coverage.out $(shell $(GO_LIST) ./... | grep -v '/doc/')
 	$(GO_TOOL) cover -html=coverage.out -o coverage.html
 
 lint: ## Run linter

--- a/index_error_test.go
+++ b/index_error_test.go
@@ -1,0 +1,120 @@
+package markdown
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGenerateIndexErrors covers the three failure paths, each of which wraps a
+// different sentinel so the caller can tell what went wrong.
+func TestGenerateIndexErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an option that fails stops the walk", func(t *testing.T) {
+		t.Parallel()
+
+		broken := func(_ *Index) error { return errors.New("bad option") }
+
+		err := GenerateIndex("testdata", broken)
+		if !errors.Is(err, ErrInitMarkdownIndex) {
+			t.Errorf("got %v, want it to wrap ErrInitMarkdownIndex", err)
+		}
+	})
+
+	t.Run("a missing directory is reported", func(t *testing.T) {
+		t.Parallel()
+
+		err := GenerateIndex(filepath.Join("testdata", "does-not-exist"), WithWriter(os.Stdout))
+		if !errors.Is(err, ErrCreateMarkdownIndex) {
+			t.Errorf("got %v, want it to wrap ErrCreateMarkdownIndex", err)
+		}
+	})
+
+	t.Run("a writer that fails is reported", func(t *testing.T) {
+		t.Parallel()
+
+		err := GenerateIndex("testdata", WithWriter(&failingWriter{}))
+		if !errors.Is(err, ErrWriteMarkdownIndex) {
+			t.Errorf("got %v, want it to wrap ErrWriteMarkdownIndex", err)
+		}
+	})
+}
+
+// TestFirstH1orH2 covers the heading lookup that gives each index entry its
+// label, including the inputs where there is nothing to find.
+func TestFirstH1orH2(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+		return path
+	}
+
+	tests := map[string]struct {
+		path string
+		want string
+	}{
+		"h1 wins":                {write("h1.md", "# Title\n## Section\n"), "Title"},
+		"h2 when there is no h1": {write("h2.md", "text\n## Section\n"), "Section"},
+		"no heading":             {write("none.md", "just text\n"), ""},
+		"empty file":             {write("empty.md", ""), ""},
+		"missing file":           {filepath.Join(dir, "absent.md"), ""},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := firstH1orH2(tt.path); got != tt.want {
+				t.Errorf("firstH1orH2(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCustomTableRejectsMismatchedRows covers the validation path: a row with
+// the wrong number of cells has to surface as an error rather than a table that
+// renders with a column missing.
+func TestCustomTableRejectsMismatchedRows(t *testing.T) {
+	t.Parallel()
+
+	m := NewMarkdown(nil).CustomTable(TableSet{
+		Header: []string{"a", "b"},
+		Rows:   [][]string{{"1"}},
+	}, TableOptions{})
+
+	if m.Error() == nil {
+		t.Fatal("a row with too few cells must be reported")
+	}
+	if !errors.Is(m.Error(), ErrMismatchColumn) {
+		t.Errorf("got %v, want it to wrap ErrMismatchColumn", m.Error())
+	}
+}
+
+// TestCustomTableOptions covers the two formatting switches, which change the
+// rendered table and had no assertion on their effect.
+func TestCustomTableOptions(t *testing.T) {
+	t.Parallel()
+
+	set := TableSet{
+		Header: []string{"name", "description"},
+		Rows:   [][]string{{"a", "a description long enough to wrap somewhere"}},
+	}
+
+	plain := NewMarkdown(nil).CustomTable(set, TableOptions{}).String()
+	formatted := NewMarkdown(nil).CustomTable(set, TableOptions{
+		AutoWrapText:      true,
+		AutoFormatHeaders: true,
+	}).String()
+
+	if plain == formatted {
+		t.Errorf("the options changed nothing:\n%s", plain)
+	}
+}

--- a/mermaid/arch/write_error_test.go
+++ b/mermaid/arch/write_error_test.go
@@ -1,0 +1,28 @@
+package arch_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/arch"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := arch.NewArchitecture(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/block/write_error_test.go
+++ b/mermaid/block/write_error_test.go
@@ -1,0 +1,28 @@
+package block_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/block"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := block.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/class/coverage_test.go
+++ b/mermaid/class/coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nao1215/markdown/internal"
 	"github.com/nao1215/markdown/mermaid/class"
 )
 
@@ -13,7 +14,7 @@ func build(t *testing.T, fn func(*class.Diagram) *class.Diagram) []string {
 	t.Helper()
 
 	d := fn(class.NewDiagram(nil))
-	lines := strings.Split(d.String(), "\n")
+	lines := strings.Split(d.String(), internal.LineFeed())
 	if len(lines) == 0 {
 		t.Fatal("diagram produced no output")
 	}

--- a/mermaid/class/coverage_test.go
+++ b/mermaid/class/coverage_test.go
@@ -1,0 +1,155 @@
+package class_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/class"
+)
+
+// build renders a diagram and returns its lines, minus the "classDiagram"
+// header, so each test can assert on the statements it produced.
+func build(t *testing.T, fn func(*class.Diagram) *class.Diagram) []string {
+	t.Helper()
+
+	d := fn(class.NewDiagram(nil))
+	lines := strings.Split(d.String(), "\n")
+	if len(lines) == 0 {
+		t.Fatal("diagram produced no output")
+	}
+	return lines[1:]
+}
+
+// TestCardinalityShorthands covers the three shorthands over WithCardinality.
+// They exist so a caller does not have to spell out the pair, and a wrong pair
+// would be invisible without an assertion on the rendered relationship.
+func TestCardinalityShorthands(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		option class.RelationOption
+		want   string
+	}{
+		"many to one": {class.WithManyToOne(), `    Order "many" *-- "1" LineItem`},
+		"one to one":  {class.WithOneToOne(), `    Order "1" *-- "1" LineItem`},
+		"many to many": {
+			class.WithManyToMany(),
+			`    Order "many" *-- "many" LineItem`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := build(t, func(d *class.Diagram) *class.Diagram {
+				return d.From("Order").Composition("LineItem", tt.option).Diagram
+			})
+			if got[0] != tt.want {
+				t.Errorf("relationship mismatch:\n got: %q\nwant: %q", got[0], tt.want)
+			}
+		})
+	}
+}
+
+// TestClassWithMembers covers the untyped member form, which is the escape
+// hatch for members the typed helpers cannot express.
+func TestClassWithMembers(t *testing.T) {
+	t.Parallel()
+
+	got := build(t, func(d *class.Diagram) *class.Diagram {
+		return d.ClassWithMembers("Order", "+int count", "+Reset()")
+	})
+
+	want := []string{
+		"    class Order {",
+		"        +int count",
+		"        +Reset()",
+		"    }",
+	}
+	for i, line := range want {
+		if i >= len(got) || got[i] != line {
+			t.Fatalf("member block mismatch at line %d:\n got: %#v\nwant: %#v", i, got, want)
+		}
+	}
+}
+
+// TestRelationshipsWithCardinality covers the composition and association
+// helpers that take cardinality, with and without a label.
+func TestRelationshipsWithCardinality(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(*class.Diagram) *class.Diagram
+		want  string
+	}{
+		"composition": {
+			build: func(d *class.Diagram) *class.Diagram {
+				return d.CompositionWithCardinality("Order", "1", "LineItem", "many")
+			},
+			want: `    Order "1" *-- "many" LineItem`,
+		},
+		"composition with label": {
+			build: func(d *class.Diagram) *class.Diagram {
+				return d.CompositionWithCardinalityAndLabel("Order", "1", "LineItem", "many", "contains")
+			},
+			want: `    Order "1" *-- "many" LineItem : contains`,
+		},
+		"association": {
+			build: func(d *class.Diagram) *class.Diagram {
+				return d.AssociationWithCardinality("Order", "1", "Payment", "0..1")
+			},
+			want: `    Order "1" --> "0..1" Payment`,
+		},
+		"association with label": {
+			build: func(d *class.Diagram) *class.Diagram {
+				return d.AssociationWithCardinalityAndLabel("Order", "1", "Payment", "0..1", "settles")
+			},
+			want: `    Order "1" --> "0..1" Payment : settles`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := build(t, tt.build); got[0] != tt.want {
+				t.Errorf("relationship mismatch:\n got: %q\nwant: %q", got[0], tt.want)
+			}
+		})
+	}
+}
+
+// TestAnnotationUsesTheClassBody pins the form GitHub accepts. The standalone
+// form, "<<Interface>> Name" on its own line, makes GitHub reject the whole
+// diagram because it lexes the leading "<" as a relationship token.
+func TestAnnotationUsesTheClassBody(t *testing.T) {
+	t.Parallel()
+
+	for name, fn := range map[string]func(*class.Diagram) *class.Diagram{
+		"Interface":           func(d *class.Diagram) *class.Diagram { return d.Interface("PaymentGateway") },
+		"ClassWithAnnotation": func(d *class.Diagram) *class.Diagram { return d.ClassWithAnnotation("PaymentGateway", "Interface") },
+		"Annotation":          func(d *class.Diagram) *class.Diagram { return d.Annotation("PaymentGateway", "<<Interface>>") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := build(t, fn)
+			want := []string{
+				"    class PaymentGateway {",
+				"        <<Interface>>",
+				"    }",
+			}
+			for i, line := range want {
+				if i >= len(got) || got[i] != line {
+					t.Fatalf("annotation mismatch:\n got: %#v\nwant: %#v", got, want)
+				}
+			}
+			for _, line := range got {
+				if strings.HasPrefix(strings.TrimSpace(line), "<<") && strings.Contains(line, ">> ") {
+					t.Errorf("standalone annotation form emitted: %q", line)
+				}
+			}
+		})
+	}
+}

--- a/mermaid/class/write_error_test.go
+++ b/mermaid/class/write_error_test.go
@@ -1,0 +1,28 @@
+package class_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/class"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := class.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/er/write_error_test.go
+++ b/mermaid/er/write_error_test.go
@@ -1,0 +1,28 @@
+package er_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/er"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := er.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/flowchart/write_error_test.go
+++ b/mermaid/flowchart/write_error_test.go
@@ -1,0 +1,28 @@
+package flowchart_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/flowchart"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := flowchart.NewFlowchart(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/gantt/error_test.go
+++ b/mermaid/gantt/error_test.go
@@ -1,0 +1,38 @@
+package gantt_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/gantt"
+)
+
+// TestChartError covers the accessor callers use to find out why a chart came
+// out wrong, which nothing exercised.
+func TestChartError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a well formed chart reports no error", func(t *testing.T) {
+		t.Parallel()
+
+		c := gantt.NewChart(nil).Section("build").Task("compile", "2024-01-01", "1d")
+		if err := c.Error(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("a nil writer is reported through Error after Build", func(t *testing.T) {
+		t.Parallel()
+
+		c := gantt.NewChart(nil)
+		if err := c.Build(); err == nil {
+			t.Fatal("Build with a nil writer must fail")
+		}
+		if c.Error() == nil {
+			t.Error("Error must report the failure Build returned")
+		}
+		if !strings.Contains(c.Error().Error(), "nil") {
+			t.Errorf("unexpected error: %v", c.Error())
+		}
+	})
+}

--- a/mermaid/gantt/write_error_test.go
+++ b/mermaid/gantt/write_error_test.go
@@ -1,0 +1,28 @@
+package gantt_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/gantt"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := gantt.NewChart(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/gitgraph/write_error_test.go
+++ b/mermaid/gitgraph/write_error_test.go
@@ -1,0 +1,28 @@
+package gitgraph_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/gitgraph"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := gitgraph.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/kanban/write_error_test.go
+++ b/mermaid/kanban/write_error_test.go
@@ -1,0 +1,28 @@
+package kanban_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/kanban"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := kanban.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/mindmap/write_error_test.go
+++ b/mermaid/mindmap/write_error_test.go
@@ -1,0 +1,28 @@
+package mindmap_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/mindmap"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := mindmap.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/packet/write_error_test.go
+++ b/mermaid/packet/write_error_test.go
@@ -1,0 +1,28 @@
+package packet_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/packet"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := packet.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/piechart/write_error_test.go
+++ b/mermaid/piechart/write_error_test.go
@@ -1,0 +1,28 @@
+package piechart_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/piechart"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := piechart.NewPieChart(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/quadrant/write_error_test.go
+++ b/mermaid/quadrant/write_error_test.go
@@ -1,0 +1,28 @@
+package quadrant_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/quadrant"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := quadrant.NewChart(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/requirement/write_error_test.go
+++ b/mermaid/requirement/write_error_test.go
@@ -1,0 +1,28 @@
+package requirement_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/requirement"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := requirement.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/sequence/write_error_test.go
+++ b/mermaid/sequence/write_error_test.go
@@ -1,0 +1,28 @@
+package sequence_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/sequence"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := sequence.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/state/coverage_test.go
+++ b/mermaid/state/coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nao1215/markdown/internal"
 	"github.com/nao1215/markdown/mermaid/state"
 )
 
@@ -11,7 +12,7 @@ import (
 func statements(t *testing.T, fn func(*state.Diagram) *state.Diagram) []string {
 	t.Helper()
 
-	lines := strings.Split(fn(state.NewDiagram(nil)).String(), "\n")
+	lines := strings.Split(fn(state.NewDiagram(nil)).String(), internal.LineFeed())
 	if len(lines) == 0 {
 		t.Fatal("diagram produced no output")
 	}

--- a/mermaid/state/coverage_test.go
+++ b/mermaid/state/coverage_test.go
@@ -1,0 +1,71 @@
+package state_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/state"
+)
+
+// statements renders the diagram and returns its lines without the header.
+func statements(t *testing.T, fn func(*state.Diagram) *state.Diagram) []string {
+	t.Helper()
+
+	lines := strings.Split(fn(state.NewDiagram(nil)).String(), "\n")
+	if len(lines) == 0 {
+		t.Fatal("diagram produced no output")
+	}
+	return lines[1:]
+}
+
+// TestStateAndTransitions covers the statement builders that had no test: a
+// wrong separator or a missing label here would render a valid-looking but
+// wrong diagram, which is the failure mode nobody notices.
+func TestStateAndTransitions(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(*state.Diagram) *state.Diagram
+		want  string
+	}{
+		"state without a description": {
+			build: func(d *state.Diagram) *state.Diagram { return d.State("Idle", "") },
+			want:  "    Idle",
+		},
+		"state with a description": {
+			build: func(d *state.Diagram) *state.Diagram { return d.State("Idle", "waiting for work") },
+			want:  "    Idle : waiting for work",
+		},
+		"transition with a note": {
+			build: func(d *state.Diagram) *state.Diagram { return d.TransitionWithNote("Idle", "Busy", "job arrives") },
+			want:  "    Idle --> Busy : job arrives",
+		},
+		"start transition with a note": {
+			build: func(d *state.Diagram) *state.Diagram { return d.StartTransitionWithNote("Idle", "boot") },
+			want:  "    [*] --> Idle : boot",
+		},
+		"end transition with a note": {
+			build: func(d *state.Diagram) *state.Diagram { return d.EndTransitionWithNote("Done", "shutdown") },
+			want:  "    Done --> [*] : shutdown",
+		},
+		"concurrent separator": {
+			build: func(d *state.Diagram) *state.Diagram { return d.Concurrent() },
+			want:  "    ---",
+		},
+		"line feed": {
+			build: func(d *state.Diagram) *state.Diagram { return d.LF() },
+			want:  "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := statements(t, tt.build)
+			if len(got) == 0 || got[0] != tt.want {
+				t.Errorf("statement mismatch:\n got: %#v\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/mermaid/state/write_error_test.go
+++ b/mermaid/state/write_error_test.go
@@ -1,0 +1,28 @@
+package state_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/state"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := state.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/userjourney/write_error_test.go
+++ b/mermaid/userjourney/write_error_test.go
@@ -1,0 +1,28 @@
+package userjourney_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/userjourney"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := userjourney.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/mermaid/xychart/coverage_test.go
+++ b/mermaid/xychart/coverage_test.go
@@ -1,0 +1,67 @@
+package xychart_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/xychart"
+)
+
+// TestXAxisRange covers the numeric x-axis, including the rejected range. A
+// chart whose axis silently fails to render is worse than one that reports the
+// problem, so the error path matters as much as the happy one.
+func TestXAxisRange(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with a title", func(t *testing.T) {
+		t.Parallel()
+
+		d := xychart.NewDiagram(nil).XAxisRangeWithTitle("Month", 1, 12)
+		if err := d.Error(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := `    x-axis Month 1 --> 12`
+		if !strings.Contains(d.String(), want) {
+			t.Errorf("axis missing from output:\n got: %q\nwant to contain: %q", d.String(), want)
+		}
+	})
+
+	t.Run("min not below max is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		d := xychart.NewDiagram(nil).XAxisRangeWithTitle("Month", 12, 12)
+		if d.Error() == nil {
+			t.Fatal("an inverted range must be reported")
+		}
+	})
+
+	t.Run("a later call is a no-op once the diagram holds an error", func(t *testing.T) {
+		t.Parallel()
+
+		d := xychart.NewDiagram(nil).
+			XAxisRangeWithTitle("Month", 12, 12).
+			XAxisRangeWithTitle("Month", 1, 12)
+
+		if strings.Contains(d.String(), "1 --> 12") {
+			t.Errorf("statement was appended after an error:\n%s", d.String())
+		}
+	})
+}
+
+// TestLineFeedStopsOnError pins the same rule for LF: once the diagram is in an
+// error state, nothing more is appended.
+func TestLineFeedStopsOnError(t *testing.T) {
+	t.Parallel()
+
+	clean := xychart.NewDiagram(nil).LF()
+	if !strings.HasSuffix(clean.String(), "\n") {
+		t.Errorf("LF did not append a blank line: %q", clean.String())
+	}
+
+	broken := xychart.NewDiagram(nil).XAxisRangeWithTitle("Month", 12, 12)
+	before := broken.String()
+	if after := broken.LF().String(); after != before {
+		t.Errorf("LF appended after an error:\n before: %q\n  after: %q", before, after)
+	}
+}

--- a/mermaid/xychart/write_error_test.go
+++ b/mermaid/xychart/write_error_test.go
@@ -1,0 +1,28 @@
+package xychart_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/xychart"
+)
+
+// errWriter fails every write, which is what a full disk or a closed pipe looks
+// like to Build.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestBuildReportsWriteFailure covers the branch where the destination accepts
+// the diagram and then fails. Silently returning nil there would hand the caller
+// a document that was never written.
+func TestBuildReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	err := xychart.NewDiagram(errWriter{}).Build()
+	if err == nil {
+		t.Fatal("Build must report a failing writer")
+	}
+}

--- a/render_test.go
+++ b/render_test.go
@@ -336,3 +336,63 @@ func TestInsertTableOfContentsWithMissingMarkers(t *testing.T) {
 		})
 	}
 }
+
+// TestWithBlockSpacing covers the opt-in that separates every block, which is
+// what markdownlint and mkdocs want. The default is deliberately tighter, so
+// both shapes are pinned here.
+func TestWithBlockSpacing(t *testing.T) {
+	t.Parallel()
+
+	chain := func(m *Markdown) *Markdown {
+		return m.H1("Title").
+			PlainText("paragraph").
+			BulletList("alpha", "beta").
+			CodeBlocks(SyntaxHighlightGo, "x := 1")
+	}
+
+	compact := chain(NewMarkdown(nil)).String()
+	spaced := chain(NewMarkdown(nil, WithBlockSpacing())).String()
+
+	wantCompact := strings.Join([]string{
+		"# Title",
+		"paragraph",
+		"- alpha",
+		"- beta",
+		"",
+		"```go",
+		"x := 1",
+		"```",
+	}, lf())
+	if diff := cmp.Diff(wantCompact, compact); diff != "" {
+		t.Errorf("default output changed (-want +got):\n%s", diff)
+	}
+
+	wantSpaced := strings.Join([]string{
+		"# Title",
+		"",
+		"paragraph",
+		"",
+		"- alpha",
+		"- beta",
+		"",
+		"```go",
+		"x := 1",
+		"```",
+	}, lf())
+	if diff := cmp.Diff(wantSpaced, spaced); diff != "" {
+		t.Errorf("spaced output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestBlankLine covers the explicit spacer, and that it is not doubled by the
+// automatic separation.
+func TestBlankLine(t *testing.T) {
+	t.Parallel()
+
+	got := NewMarkdown(nil).BulletList("alpha").BlankLine().PlainText("after").String()
+	want := strings.Join([]string{"- alpha", "", "after"}, lf())
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("blank line mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
## What the number was measuring

Coverage ran over `./...`, which includes the 22 sample programs under `doc/`. Their `main()` is never called by a test, so roughly a fifth of the statements being counted were documentation. Coverage now runs over the library packages only, in CI and in `make test`.

On that basis the starting point was **92.8%**. It is **95.2%** now.

## What was missing

The gap was whole functions nothing called, not lines nothing reached:

- **class** — the three cardinality shorthands, `ClassWithMembers`, and the four composition/association helpers that take cardinality.
- **state** — `State`, `TransitionWithNote`, `StartTransitionWithNote`, `EndTransitionWithNote`, `Concurrent`, `LF`.
- **xychart** — the numeric x-axis, including the rejected range and the rule that nothing is appended once the diagram holds an error.
- **gantt** — `Error`, the accessor callers use to find out why a chart came out wrong.
- **every mermaid subpackage** — `Build` against a writer that fails, which is what a full disk or a closed pipe looks like.
- **markdown** — `WithBlockSpacing`, `BlankLine`, the three `GenerateIndex` failure paths and their sentinels, `firstH1orH2` with no heading and no file, and `CustomTable` rejecting a short row.

The class annotation test pins the body form as well, so the standalone `<<Interface>> Name` that GitHub rejects cannot come back unnoticed.

## What is left uncovered

The remainder is mostly the Windows branch of `internal.LineFeed` and `normalizeLineFeeds`, which cannot run on the Linux job that produces the profile.

## Downstream impact

None. Tests and CI configuration only.

https://claude.ai/code/session_01LL48LunC16NCDh17BU9VmG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diagram generation now reliably reports errors when output cannot be written.
  * Improved validation for invalid chart ranges, mismatched table rows, and other malformed input.
  * Rendering behavior is more consistent for headings, annotations, line endings, and block spacing.
  * Prevented further diagram modifications after certain rendering errors.

* **Tests**
  * Expanded coverage across Mermaid diagram types, table formatting, state diagrams, class diagrams, chart rendering, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->