### PR TITLE
fix: address the review findings left open on merged pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract tag name
         id: tag

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -37,5 +37,10 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      # Same package scope as coverage.yml: doc/ holds sample programs whose
+      # main() no test calls, so counting them measures the samples.
       - name: Run tests with coverage report output
-        run: go test -cover -coverpkg=./... -coverprofile=coverage.out ./...
+        shell: bash
+        run: |
+          pkgs="$(go list ./... | grep -v '/doc/')"
+          go test -cover -coverpkg="$(echo "$pkgs" | paste -sd,)" -coverprofile=coverage.out $pkgs

--- a/mermaid/arch/write_error_test.go
+++ b/mermaid/arch/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/arch"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := arch.NewArchitecture(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/block/write_error_test.go
+++ b/mermaid/block/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/block"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := block.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/class/write_error_test.go
+++ b/mermaid/class/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/class"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := class.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/er/write_error_test.go
+++ b/mermaid/er/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/er"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := er.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/flowchart/write_error_test.go
+++ b/mermaid/flowchart/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/flowchart"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := flowchart.NewFlowchart(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/gantt/write_error_test.go
+++ b/mermaid/gantt/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/gantt"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := gantt.NewChart(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/gitgraph/write_error_test.go
+++ b/mermaid/gitgraph/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/gitgraph"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := gitgraph.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/kanban/write_error_test.go
+++ b/mermaid/kanban/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/kanban"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := kanban.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/mindmap/write_error_test.go
+++ b/mermaid/mindmap/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/mindmap"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := mindmap.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/packet/write_error_test.go
+++ b/mermaid/packet/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/packet"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := packet.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/piechart/write_error_test.go
+++ b/mermaid/piechart/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/piechart"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := piechart.NewPieChart(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/quadrant/write_error_test.go
+++ b/mermaid/quadrant/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/quadrant"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := quadrant.NewChart(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/requirement/write_error_test.go
+++ b/mermaid/requirement/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/requirement"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := requirement.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/sequence/write_error_test.go
+++ b/mermaid/sequence/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/sequence"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := sequence.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/state/write_error_test.go
+++ b/mermaid/state/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/state"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := state.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/userjourney/write_error_test.go
+++ b/mermaid/userjourney/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/userjourney"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := userjourney.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }

--- a/mermaid/xychart/write_error_test.go
+++ b/mermaid/xychart/write_error_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/nao1215/markdown/mermaid/xychart"
 )
 
+// errWrite is the failure the writer below reports, so the test can assert that
+// Build passed it through rather than inventing an error of its own.
+var errWrite = errors.New("write failed")
+
 // errWriter fails every write, which is what a full disk or a closed pipe looks
 // like to Build.
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {
-	return 0, errors.New("write failed")
+	return 0, errWrite
 }
 
 // TestBuildReportsWriteFailure covers the branch where the destination accepts
@@ -24,5 +28,8 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	err := xychart.NewDiagram(errWriter{}).Build()
 	if err == nil {
 		t.Fatal("Build must report a failing writer")
+	}
+	if !errors.Is(err, errWrite) {
+		t.Errorf("Build lost the destination error: %v", err)
 	}
 }


### PR DESCRIPTION
## What

Three CodeRabbit findings that were raised but not acted on before their pull requests merged.

**`release.yml` left the token in the git config (#109).** The checkout there had no `persist-credentials: false`, so `GITHUB_TOKEN` stayed in the local git configuration for the rest of the job. Every other workflow in the repository already sets it.

**Two workflows measured different things (#115).** `coverage.yml` filters out the `doc/` sample programs, whose `main()` no test calls; `unit_test.yml` still ran `-coverpkg=./...`. The same commit produced two different coverage numbers depending on which workflow you read. Both use the same package list now.

**The write-error tests were too weak to fail (#115).** They asserted only that `Build` returned something non-nil, which passes even if `Build` throws the destination error away and reports one of its own. Each subpackage now asserts `errors.Is` against the writer's sentinel, so the wrapping is what is actually being checked.

## Downstream impact

None. Workflows and tests only.

https://claude.ai/code/session_01LL48LunC16NCDh17BU9VmG