### PR TITLE
fix(block): put the block diagram title in the front matter

### DIFF
--- a/.github/workflows/doc_render.yml
+++ b/.github/workflows/doc_render.yml
@@ -1,9 +1,9 @@
 name: DocRender
 
 # This package exists to emit markdown, so "does the output render" is part of
-# its contract. The Go tests only compare strings; this job runs the real
-# mermaid parser over every diagram committed here, which is the closest thing
-# to what a reader's browser does with them.
+# its contract. The Go tests only compare strings; this job draws every diagram
+# committed here with the real mermaid renderer in a real browser, which is what
+# a reader's browser does with them.
 on:
   workflow_dispatch:
   push:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   mermaid:
-    name: Parse committed mermaid diagrams
+    name: Render committed mermaid diagrams
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -30,11 +30,24 @@ jobs:
           cache: npm
           cache-dependency-path: scripts/mermaid-check/package-lock.json
 
-      - name: Install the mermaid parser
+      # Rendering needs the layout and text measurement only a browser has, so
+      # npm ci pulls the Chrome build puppeteer pins. It lands in ~/.cache and
+      # the download is the slow part, hence the cache.
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('scripts/mermaid-check/package-lock.json') }}
+
+      - name: Install the mermaid renderer
         run: npm ci
         working-directory: scripts/mermaid-check
 
-      - name: Parse every mermaid block
+      # A checker that catches nothing looks like a checker with nothing to
+      # catch, so the fixtures run first.
+      - name: Check the checker
+        run: node scripts/mermaid-check/selftest.mjs
+
+      - name: Render every mermaid block
         # NUL-delimited so a path containing whitespace stays one argument.
         run: git ls-files -z '*.md' | node scripts/mermaid-check/check.mjs --stdin0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 - When creating a bug report: Please follow the template and provide detailed information.
 - When fixing a feature: Create a Pull Request (PR) with accompanying test code.
 - When adding a feature: First, propose the feature in an Issue.
+- When touching a mermaid builder: Run `make generate` to refresh the samples under `doc/`, then `make render-check`. The latter draws every diagram committed here with the real mermaid renderer, which is the only thing that catches a diagram that ships, parses, and still shows the reader something else.
 
 ## Contributing Outside of Coding
 The following actions help boost my motivation:

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,9 @@ lint: ## Run linter
 generate: ## Regenerate the sample documents under doc/ (CheckAutoGenerateFiles verifies these)
 	$(GO) generate ./...
 
-render-check: ## Parse every mermaid diagram committed in this repository (requires node)
+render-check: ## Render every mermaid diagram committed in this repository (requires node)
 	cd scripts/mermaid-check && npm ci
+	node scripts/mermaid-check/selftest.mjs
 	git ls-files -z '*.md' | node scripts/mermaid-check/check.mjs --stdin0
 
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -892,8 +892,10 @@ Plain text output: [markdown is here](./doc/block/generated.md)
 ````text
 ## Block Diagram
 ```mermaid
+---
+title: Checkout Architecture
+---
 block
-    title Checkout Architecture
     columns 3
     Frontend toBackend<["calls"]>(right) Backend
     space:2 toDB<["&nbsp;"]>(down)
@@ -905,8 +907,10 @@ block
 
 Mermaid output:
 ```mermaid
+---
+title: Checkout Architecture
+---
 block
-    title Checkout Architecture
     columns 3
     Frontend toBackend<["calls"]>(right) Backend
     space:2 toDB<["&nbsp;"]>(down)

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ Plain text output: [markdown is here](./doc/gitgraph/generated.md)
 ## Git Graph
 ```mermaid
 ---
-title: Release Flow
+title: "Release Flow"
 ---
 gitGraph
     commit id: "init" tag: "v0.1.0"
@@ -516,7 +516,7 @@ gitGraph
 Mermaid output:
 ```mermaid
 ---
-title: Release Flow
+title: "Release Flow"
 ---
 gitGraph
     commit id: "init" tag: "v0.1.0"
@@ -571,7 +571,7 @@ Plain text output: [markdown is here](./doc/mindmap/generated.md)
 ## Mindmap
 ```mermaid
 ---
-title: Product Strategy Mindmap
+title: "Product Strategy Mindmap"
 ---
 mindmap
     Product Strategy
@@ -587,7 +587,7 @@ mindmap
 Mermaid output:
 ```mermaid
 ---
-title: Product Strategy Mindmap
+title: "Product Strategy Mindmap"
 ---
 mindmap
     Product Strategy
@@ -665,7 +665,7 @@ Plain text output: [markdown is here](./doc/requirement/generated.md)
 ## Requirement Diagram
 ```mermaid
 ---
-title: Checkout Requirements
+title: "Checkout Requirements"
 ---
 requirementDiagram
     direction TB
@@ -695,7 +695,7 @@ requirementDiagram
 Mermaid output:
 ```mermaid
 ---
-title: Checkout Requirements
+title: "Checkout Requirements"
 ---
 requirementDiagram
     direction TB
@@ -893,7 +893,7 @@ Plain text output: [markdown is here](./doc/block/generated.md)
 ## Block Diagram
 ```mermaid
 ---
-title: Checkout Architecture
+title: "Checkout Architecture"
 ---
 block
     columns 3
@@ -908,7 +908,7 @@ block
 Mermaid output:
 ```mermaid
 ---
-title: Checkout Architecture
+title: "Checkout Architecture"
 ---
 block
     columns 3
@@ -966,7 +966,7 @@ Plain text output: [markdown is here](./doc/kanban/generated.md)
 ## Kanban Diagram
 ```mermaid
 ---
-title: Sprint Board
+title: "Sprint Board"
 config:
   kanban:
     ticketBaseUrl: 'https://example.com/tickets/'
@@ -983,7 +983,7 @@ kanban
 Mermaid output:
 ```mermaid
 ---
-title: Sprint Board
+title: "Sprint Board"
 config:
   kanban:
     ticketBaseUrl: 'https://example.com/tickets/'
@@ -1226,7 +1226,7 @@ Plain text output: [markdown is here](./doc/flowchart/generated.md)
 ## Flowchart
 ```mermaid
 ---
-title: mermaid flowchart builder
+title: "mermaid flowchart builder"
 ---
 flowchart TB
 	A["Node A"]
@@ -1508,7 +1508,7 @@ Plain text output: [markdown is here](./doc/state/generated.md)
 ## State Diagram
 ```mermaid
 ---
-title: Order State Machine
+title: "Order State Machine"
 ---
 stateDiagram-v2
     [*] --> Pending
@@ -1531,7 +1531,7 @@ stateDiagram-v2
 Mermaid output:
 ```mermaid
 ---
-title: Order State Machine
+title: "Order State Machine"
 ---
 stateDiagram-v2
     [*] --> Pending
@@ -1615,7 +1615,7 @@ Plain text output: [markdown is here](./doc/class/generated.md)
 ## Class Diagram
 ```mermaid
 ---
-title: Checkout Domain
+title: "Checkout Domain"
 ---
 classDiagram
     direction LR
@@ -1641,7 +1641,7 @@ classDiagram
 Mermaid output:
 ```mermaid
 ---
-title: Checkout Domain
+title: "Checkout Domain"
 ---
 classDiagram
     direction LR

--- a/doc/block/generated.md
+++ b/doc/block/generated.md
@@ -1,8 +1,10 @@
 ## Block Diagram
 
 ```mermaid
+---
+title: Checkout Architecture
+---
 block
-    title Checkout Architecture
     columns 3
     Frontend toBackend<["calls"]>(right) Backend
     space:2 toDB<["&nbsp;"]>(down)

--- a/doc/block/generated.md
+++ b/doc/block/generated.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 ---
-title: Checkout Architecture
+title: "Checkout Architecture"
 ---
 block
     columns 3

--- a/doc/class/generated.md
+++ b/doc/class/generated.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 ---
-title: Checkout Domain
+title: "Checkout Domain"
 ---
 classDiagram
     direction LR

--- a/doc/flowchart/generated.md
+++ b/doc/flowchart/generated.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 ---
-title: mermaid flowchart builder
+title: "mermaid flowchart builder"
 ---
 flowchart TB
     A["Node A"]

--- a/doc/gitgraph/generated.md
+++ b/doc/gitgraph/generated.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 ---
-title: Release Flow
+title: "Release Flow"
 ---
 gitGraph
     commit id: "init" tag: "v0.1.0"

--- a/doc/kanban/generated.md
+++ b/doc/kanban/generated.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 ---
-title: Sprint Board
+title: "Sprint Board"
 config:
   kanban:
     ticketBaseUrl: 'https://example.com/tickets/'

--- a/doc/mindmap/generated.md
+++ b/doc/mindmap/generated.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 ---
-title: Product Strategy Mindmap
+title: "Product Strategy Mindmap"
 ---
 mindmap
     Product Strategy

--- a/doc/requirement/generated.md
+++ b/doc/requirement/generated.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 ---
-title: Checkout Requirements
+title: "Checkout Requirements"
 ---
 requirementDiagram
     direction TB

--- a/doc/state/generated.md
+++ b/doc/state/generated.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 ---
-title: Order State Machine
+title: "Order State Machine"
 ---
 stateDiagram-v2
     [*] --> Pending

--- a/internal/frontmatter.go
+++ b/internal/frontmatter.go
@@ -3,7 +3,7 @@ package internal
 
 import (
 	"fmt"
-	"strings"
+	"strconv"
 )
 
 // FrontMatterTitle returns the `title:` line of a mermaid front matter block.
@@ -19,16 +19,13 @@ func FrontMatterTitle(title string) string {
 }
 
 // quoteYAML returns value as a double quoted YAML scalar.
+//
+// strconv.Quote does the escaping because Go's double quoted form and YAML's
+// agree on every escape it emits: \\, \", the \a \b \f \n \r \t \v shorthands,
+// and the \xNN, \uNNNN and \UNNNNNNNN forms for everything else. Hand rolling
+// the replacements misses the control characters that have no shorthand, and a
+// literal control character inside a quoted scalar is a parse error, which loses
+// the whole diagram rather than mangling one line of it.
 func quoteYAML(value string) string {
-	// The characters a double quoted YAML scalar cannot carry as themselves. The
-	// backslash comes first, or it would escape the backslashes that the later
-	// replacements introduce.
-	escapes := strings.NewReplacer(
-		`\`, `\\`,
-		`"`, `\"`,
-		"\n", `\n`,
-		"\r", `\r`,
-		"\t", `\t`,
-	)
-	return `"` + escapes.Replace(value) + `"`
+	return strconv.Quote(value)
 }

--- a/internal/frontmatter.go
+++ b/internal/frontmatter.go
@@ -1,0 +1,34 @@
+// Package internal package is used to store the internal implementation of the mermaid package.
+package internal
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FrontMatterTitle returns the `title:` line of a mermaid front matter block.
+//
+// The value is always a double quoted YAML scalar, because mermaid runs the
+// front matter through a YAML parser before it draws anything and a bare scalar
+// is not safe to build from arbitrary text. "Checkout: API" and "*ref" make that
+// parser throw, which loses the whole diagram; "Checkout # API" is truncated at
+// the comment, and "~", "# Checkout" and "&anchor" resolve to something that is
+// not the title at all. Quoting removes every one of those readings.
+func FrontMatterTitle(title string) string {
+	return fmt.Sprintf("title: %s", quoteYAML(title))
+}
+
+// quoteYAML returns value as a double quoted YAML scalar.
+func quoteYAML(value string) string {
+	// The characters a double quoted YAML scalar cannot carry as themselves. The
+	// backslash comes first, or it would escape the backslashes that the later
+	// replacements introduce.
+	escapes := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		"\n", `\n`,
+		"\r", `\r`,
+		"\t", `\t`,
+	)
+	return `"` + escapes.Replace(value) + `"`
+}

--- a/internal/frontmatter_test.go
+++ b/internal/frontmatter_test.go
@@ -81,9 +81,26 @@ func TestFrontMatterTitle(t *testing.T) {
 			want:  `title: "Checkout\\\"API"`,
 		},
 		{
-			name:  "control characters are escaped",
+			name:  "control characters with a shorthand are escaped",
 			title: "Checkout\tAPI\r\nv2",
 			want:  `title: "Checkout\tAPI\r\nv2"`,
+		},
+		{
+			// Left literal, these end the scalar with "expected valid JSON
+			// character" and take the diagram down with them.
+			name:  "control characters without a shorthand are escaped",
+			title: "Checkout\x01API\x1bv2\x7f",
+			want:  `title: "Checkout\x01API\x1bv2\x7f"`,
+		},
+		{
+			name:  "vertical tab and bell keep their shorthand",
+			title: "Checkout\vAPI\av2",
+			want:  `title: "Checkout\vAPI\av2"`,
+		},
+		{
+			name:  "printable non-ASCII is left alone",
+			title: "Café ☕",
+			want:  `title: "Café ☕"`,
 		},
 		{
 			name:  "empty title",

--- a/internal/frontmatter_test.go
+++ b/internal/frontmatter_test.go
@@ -1,0 +1,104 @@
+// Package internal package is used to store the internal implementation of the mermaid package.
+package internal
+
+import "testing"
+
+func TestFrontMatterTitle(t *testing.T) {
+	t.Parallel()
+
+	// Every case here is a title that a bare YAML scalar reads as something
+	// other than the title. The colon and the alias make mermaid's front matter
+	// parser throw, which loses the whole diagram; the rest are quietly
+	// truncated, dropped, or turned into another YAML type.
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{
+			name:  "plain title",
+			title: "Checkout Architecture",
+			want:  `title: "Checkout Architecture"`,
+		},
+		{
+			name:  "colon would end the mapping key",
+			title: "Checkout: API",
+			want:  `title: "Checkout: API"`,
+		},
+		{
+			name:  "hash would start a comment",
+			title: "Checkout # API",
+			want:  `title: "Checkout # API"`,
+		},
+		{
+			name:  "leading hash would comment out the value",
+			title: "# Checkout",
+			want:  `title: "# Checkout"`,
+		},
+		{
+			name:  "asterisk would be an alias",
+			title: "*ref",
+			want:  `title: "*ref"`,
+		},
+		{
+			name:  "ampersand would be an anchor",
+			title: "&anchor",
+			want:  `title: "&anchor"`,
+		},
+		{
+			name:  "tilde would be null",
+			title: "~",
+			want:  `title: "~"`,
+		},
+		{
+			name:  "brackets would be a sequence",
+			title: "[Checkout]",
+			want:  `title: "[Checkout]"`,
+		},
+		{
+			name:  "true would be a boolean",
+			title: "true",
+			want:  `title: "true"`,
+		},
+		{
+			name:  "digits would be a number",
+			title: "123",
+			want:  `title: "123"`,
+		},
+		{
+			name:  "double quote is escaped",
+			title: `Checkout "API"`,
+			want:  `title: "Checkout \"API\""`,
+		},
+		{
+			name:  "backslash is escaped",
+			title: `Checkout\API`,
+			want:  `title: "Checkout\\API"`,
+		},
+		{
+			name:  "backslash before a quote stays two separate escapes",
+			title: `Checkout\"API`,
+			want:  `title: "Checkout\\\"API"`,
+		},
+		{
+			name:  "control characters are escaped",
+			title: "Checkout\tAPI\r\nv2",
+			want:  `title: "Checkout\tAPI\r\nv2"`,
+		},
+		{
+			name:  "empty title",
+			title: "",
+			want:  `title: ""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := FrontMatterTitle(tt.title); got != tt.want {
+				t.Errorf("FrontMatterTitle(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}

--- a/mermaid/block/block_diagram.go
+++ b/mermaid/block/block_diagram.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	// blockLinesCap is the max initial lines in block diagram.
-	blockLinesCap int = 2
+	// blockLinesCap is the max initial lines in block diagram: the three front
+	// matter lines a title needs, plus the "block" keyword.
+	blockLinesCap int = 4
 )
 
 // Direction is the direction for block arrows.
@@ -91,8 +92,10 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 	}
 
 	lines := make([]string, 0, blockLinesCap)
-	lines = append(lines, "block")
 
+	// The title goes in the front matter, not in the diagram body. "title X" is
+	// not a block diagram statement: mermaid parses it as the row "title X",
+	// which draws two stray blocks labelled "title" and "X" instead of a title.
 	trimmedTitle := strings.TrimSpace(c.title)
 	if trimmedTitle != noTitle {
 		if containsNewline(trimmedTitle) {
@@ -103,8 +106,9 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 				indent: 1,
 			}
 		}
-		lines = append(lines, fmt.Sprintf("    title %s", trimmedTitle))
+		lines = append(lines, "---", fmt.Sprintf("title: %s", trimmedTitle), "---")
 	}
+	lines = append(lines, "block")
 
 	return &Diagram{
 		body:   lines,

--- a/mermaid/block/block_diagram.go
+++ b/mermaid/block/block_diagram.go
@@ -95,7 +95,7 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 
 	// The title goes in the front matter, not in the diagram body. "title X" is
 	// not a block diagram statement: mermaid parses it as the row "title X",
-	// which draws two stray blocks labelled "title" and "X" instead of a title.
+	// which draws two stray blocks labeled "title" and "X" instead of a title.
 	trimmedTitle := strings.TrimSpace(c.title)
 	if trimmedTitle != noTitle {
 		if containsNewline(trimmedTitle) {
@@ -106,7 +106,7 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 				indent: 1,
 			}
 		}
-		lines = append(lines, "---", fmt.Sprintf("title: %s", trimmedTitle), "---")
+		lines = append(lines, "---", internal.FrontMatterTitle(trimmedTitle), "---")
 	}
 	lines = append(lines, "block")
 

--- a/mermaid/block/block_diagram_test.go
+++ b/mermaid/block/block_diagram_test.go
@@ -33,8 +33,10 @@ func TestNewDiagram(t *testing.T) {
 		{
 			name: "new diagram with title",
 			opts: []Option{WithTitle("Checkout Architecture")},
-			want: `block
-    title Checkout Architecture`,
+			want: `---
+title: Checkout Architecture
+---
+block`,
 		},
 		{
 			name:    "new diagram with title including newline",
@@ -98,8 +100,10 @@ func TestDiagram_Build(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := `block
-    title Checkout Architecture
+	want := `---
+title: Checkout Architecture
+---
+block
     columns 3
     Frontend toBackend<["calls"]>(right) Backend
     space:2 toDB<["&nbsp;"]>(down)

--- a/mermaid/block/block_diagram_test.go
+++ b/mermaid/block/block_diagram_test.go
@@ -34,7 +34,7 @@ func TestNewDiagram(t *testing.T) {
 			name: "new diagram with title",
 			opts: []Option{WithTitle("Checkout Architecture")},
 			want: `---
-title: Checkout Architecture
+title: "Checkout Architecture"
 ---
 block`,
 		},
@@ -101,7 +101,7 @@ func TestDiagram_Build(t *testing.T) {
 	}
 
 	want := `---
-title: Checkout Architecture
+title: "Checkout Architecture"
 ---
 block
     columns 3

--- a/mermaid/block/config.go
+++ b/mermaid/block/config.go
@@ -21,7 +21,12 @@ const (
 // Option sets the options for the Diagram struct.
 type Option func(*config)
 
-// WithTitle sets the title configuration.
+// WithTitle sets the title configuration. The title is emitted as front matter,
+// which is the only place mermaid accepts one for a block diagram.
+//
+// Note that mermaid's block renderer does not draw the title today; it keeps it
+// as diagram metadata. Put the wording readers must see in the blocks
+// themselves if it matters.
 func WithTitle(title string) Option {
 	return func(c *config) {
 		c.title = title

--- a/mermaid/block/examples_test.go
+++ b/mermaid/block/examples_test.go
@@ -46,8 +46,10 @@ func ExampleDiagram() {
 	// Output:
 	// ## Block Diagram
 	// ```mermaid
+	// ---
+	// title: Checkout Architecture
+	// ---
 	// block
-	//     title Checkout Architecture
 	//     columns 3
 	//     Frontend toBackend<["calls"]>(right) Backend
 	//     space:2 toDB<["&nbsp;"]>(down)

--- a/mermaid/block/examples_test.go
+++ b/mermaid/block/examples_test.go
@@ -47,7 +47,7 @@ func ExampleDiagram() {
 	// ## Block Diagram
 	// ```mermaid
 	// ---
-	// title: Checkout Architecture
+	// title: "Checkout Architecture"
 	// ---
 	// block
 	//     columns 3

--- a/mermaid/class/class_diagram.go
+++ b/mermaid/class/class_diagram.go
@@ -35,7 +35,7 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 	lines := []string{}
 	if c.title != noTitle {
 		lines = append(lines, "---")
-		lines = append(lines, fmt.Sprintf("title: %s", c.title))
+		lines = append(lines, internal.FrontMatterTitle(c.title))
 		lines = append(lines, "---")
 	}
 	lines = append(lines, "classDiagram")

--- a/mermaid/class/class_diagram_test.go
+++ b/mermaid/class/class_diagram_test.go
@@ -33,7 +33,7 @@ func TestNewDiagram(t *testing.T) {
 			name: "new diagram with title",
 			opts: []Option{WithTitle("Checkout Domain")},
 			want: `---
-title: Checkout Domain
+title: "Checkout Domain"
 ---
 classDiagram`,
 		},
@@ -89,7 +89,7 @@ func TestDiagram_Build(t *testing.T) {
 	}
 
 	want := `---
-title: Checkout Domain
+title: "Checkout Domain"
 ---
 classDiagram
     direction LR

--- a/mermaid/class/examples_test.go
+++ b/mermaid/class/examples_test.go
@@ -51,7 +51,7 @@ func ExampleDiagram() {
 	// ## Class Diagram
 	// ```mermaid
 	// ---
-	// title: Checkout Domain
+	// title: "Checkout Domain"
 	// ---
 	// classDiagram
 	//     direction LR

--- a/mermaid/flowchart/examples_test.go
+++ b/mermaid/flowchart/examples_test.go
@@ -38,7 +38,7 @@ func ExampleFlowchart() {
 	// ## Flowchart
 	// ```mermaid
 	// ---
-	// title: mermaid flowchart builder
+	// title: "mermaid flowchart builder"
 	// ---
 	// flowchart TB
 	//     A["Node A"]

--- a/mermaid/flowchart/flowchart.go
+++ b/mermaid/flowchart/flowchart.go
@@ -33,7 +33,7 @@ func NewFlowchart(w io.Writer, opts ...Option) *Flowchart {
 	lines := []string{}
 	if strings.TrimSpace(c.title) != noTitle {
 		lines = append(lines, "---")
-		lines = append(lines, fmt.Sprintf("title: %s", c.title))
+		lines = append(lines, internal.FrontMatterTitle(c.title))
 		lines = append(lines, "---")
 	}
 	lines = append(lines, fmt.Sprintf("flowchart %s", c.oriental.string()))

--- a/mermaid/flowchart/flowchart_test.go
+++ b/mermaid/flowchart/flowchart_test.go
@@ -36,7 +36,7 @@ func TestFlowchart_Build(t *testing.T) {
 		}
 
 		want := `---
-title: mermaid flowchart builder
+title: "mermaid flowchart builder"
 ---
 flowchart TB
     A["Node A"]

--- a/mermaid/gitgraph/examples_test.go
+++ b/mermaid/gitgraph/examples_test.go
@@ -36,7 +36,7 @@ func ExampleDiagram() {
 	// ## Git Graph
 	// ```mermaid
 	// ---
-	// title: Release Flow
+	// title: "Release Flow"
 	// ---
 	// gitGraph
 	//     commit id: "init" tag: "v0.1.0"

--- a/mermaid/gitgraph/git_graph.go
+++ b/mermaid/gitgraph/git_graph.go
@@ -54,7 +54,7 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 			}
 		}
 		lines = append(lines, "---")
-		lines = append(lines, fmt.Sprintf("title: %s", c.title))
+		lines = append(lines, internal.FrontMatterTitle(c.title))
 		lines = append(lines, "---")
 	}
 	lines = append(lines, "gitGraph")

--- a/mermaid/gitgraph/git_graph_test.go
+++ b/mermaid/gitgraph/git_graph_test.go
@@ -34,7 +34,7 @@ func TestNewDiagram(t *testing.T) {
 			name: "new diagram with title",
 			opts: []Option{WithTitle("Release Flow")},
 			want: `---
-title: Release Flow
+title: "Release Flow"
 ---
 gitGraph`,
 		},
@@ -91,7 +91,7 @@ func TestDiagram_Build(t *testing.T) {
 	}
 
 	want := `---
-title: Release Flow
+title: "Release Flow"
 ---
 gitGraph
     commit id: "init" tag: "v0.1.0"

--- a/mermaid/kanban/config.go
+++ b/mermaid/kanban/config.go
@@ -26,7 +26,12 @@ const (
 // Option sets the options for the Diagram struct.
 type Option func(*config)
 
-// WithTitle sets the title configuration.
+// WithTitle sets the title configuration. The title is emitted as front matter,
+// which is the only place mermaid accepts one for a kanban board.
+//
+// Note that mermaid's kanban board renderer does not draw the title today; it keeps it
+// as diagram metadata. Put the wording readers must see in the cards
+// themselves if it matters.
 func WithTitle(title string) Option {
 	return func(c *config) {
 		c.title = title

--- a/mermaid/kanban/examples_test.go
+++ b/mermaid/kanban/examples_test.go
@@ -41,7 +41,7 @@ func ExampleDiagram() {
 	// ## Kanban Diagram
 	// ```mermaid
 	// ---
-	// title: Sprint Board
+	// title: "Sprint Board"
 	// config:
 	//   kanban:
 	//     ticketBaseUrl: 'https://example.com/tickets/'

--- a/mermaid/kanban/kanban.go
+++ b/mermaid/kanban/kanban.go
@@ -74,7 +74,7 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 	if trimmedTitle != noTitle || trimmedTicketBaseURL != noTicketBaseURL {
 		lines = append(lines, "---")
 		if trimmedTitle != noTitle {
-			lines = append(lines, fmt.Sprintf("title: %s", trimmedTitle))
+			lines = append(lines, internal.FrontMatterTitle(trimmedTitle))
 		}
 		if trimmedTicketBaseURL != noTicketBaseURL {
 			lines = append(lines, "config:")

--- a/mermaid/kanban/kanban_test.go
+++ b/mermaid/kanban/kanban_test.go
@@ -34,7 +34,7 @@ func TestNewDiagram(t *testing.T) {
 			name: "new diagram with title",
 			opts: []Option{WithTitle("Sprint Board")},
 			want: `---
-title: Sprint Board
+title: "Sprint Board"
 ---
 kanban`,
 		},
@@ -55,7 +55,7 @@ kanban`,
 				WithTicketBaseURL("https://example.com/tickets/"),
 			},
 			want: `---
-title: Sprint Board
+title: "Sprint Board"
 config:
   kanban:
     ticketBaseUrl: 'https://example.com/tickets/'
@@ -136,7 +136,7 @@ func TestDiagram_Build(t *testing.T) {
 	}
 
 	want := `---
-title: Sprint Board
+title: "Sprint Board"
 config:
   kanban:
     ticketBaseUrl: 'https://example.com/tickets/'

--- a/mermaid/mindmap/config.go
+++ b/mermaid/mindmap/config.go
@@ -21,7 +21,12 @@ const (
 // Option sets the options for the Diagram struct.
 type Option func(*config)
 
-// WithTitle sets the title configuration.
+// WithTitle sets the title configuration. The title is emitted as front matter,
+// which is the only place mermaid accepts one for a mindmap.
+//
+// Note that mermaid's mindmap renderer does not draw the title today; it keeps it
+// as diagram metadata. Put the wording readers must see in the nodes
+// themselves if it matters.
 func WithTitle(title string) Option {
 	return func(c *config) {
 		c.title = title

--- a/mermaid/mindmap/examples_test.go
+++ b/mermaid/mindmap/examples_test.go
@@ -38,7 +38,7 @@ func ExampleDiagram() {
 	// ## Mindmap
 	// ```mermaid
 	// ---
-	// title: Product Strategy Mindmap
+	// title: "Product Strategy Mindmap"
 	// ---
 	// mindmap
 	//     Product Strategy

--- a/mermaid/mindmap/mindmap.go
+++ b/mermaid/mindmap/mindmap.go
@@ -50,7 +50,7 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 			}
 		}
 		lines = append(lines, "---")
-		lines = append(lines, fmt.Sprintf("title: %s", title))
+		lines = append(lines, internal.FrontMatterTitle(title))
 		lines = append(lines, "---")
 	}
 	lines = append(lines, "mindmap")

--- a/mermaid/mindmap/mindmap_test.go
+++ b/mermaid/mindmap/mindmap_test.go
@@ -34,7 +34,7 @@ func TestNewDiagram(t *testing.T) {
 			name: "new diagram with title",
 			opts: []Option{WithTitle("Product Strategy Mindmap")},
 			want: `---
-title: Product Strategy Mindmap
+title: "Product Strategy Mindmap"
 ---
 mindmap`,
 		},
@@ -87,7 +87,7 @@ func TestDiagram_Build(t *testing.T) {
 	}
 
 	want := `---
-title: Product Strategy Mindmap
+title: "Product Strategy Mindmap"
 ---
 mindmap
     Product Strategy

--- a/mermaid/requirement/examples_test.go
+++ b/mermaid/requirement/examples_test.go
@@ -40,7 +40,7 @@ func ExampleDiagram() {
 	// ## Requirement Diagram
 	// ```mermaid
 	// ---
-	// title: Checkout Requirements
+	// title: "Checkout Requirements"
 	// ---
 	// requirementDiagram
 	//     requirement Login {

--- a/mermaid/requirement/requirement_diagram.go
+++ b/mermaid/requirement/requirement_diagram.go
@@ -125,7 +125,7 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 			}
 		}
 		lines = append(lines, "---")
-		lines = append(lines, fmt.Sprintf("title: %s", title))
+		lines = append(lines, internal.FrontMatterTitle(title))
 		lines = append(lines, "---")
 	}
 	lines = append(lines, "requirementDiagram")

--- a/mermaid/requirement/requirement_diagram_test.go
+++ b/mermaid/requirement/requirement_diagram_test.go
@@ -34,7 +34,7 @@ func TestNewDiagram(t *testing.T) {
 			name: "new diagram with title",
 			opts: []Option{WithTitle("Checkout Requirements")},
 			want: `---
-title: Checkout Requirements
+title: "Checkout Requirements"
 ---
 requirementDiagram`,
 		},
@@ -111,7 +111,7 @@ func TestDiagram_Build(t *testing.T) {
 	}
 
 	want := `---
-title: Checkout Requirements
+title: "Checkout Requirements"
 ---
 requirementDiagram
     direction TB

--- a/mermaid/state/examples_test.go
+++ b/mermaid/state/examples_test.go
@@ -33,7 +33,7 @@ func ExampleDiagram() {
 	// ## State Diagram
 	// ```mermaid
 	// ---
-	// title: Simple State Diagram
+	// title: "Simple State Diagram"
 	// ---
 	// stateDiagram-v2
 	//     [*] --> Still

--- a/mermaid/state/state_diagram.go
+++ b/mermaid/state/state_diagram.go
@@ -33,7 +33,7 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 	lines := []string{}
 	if c.title != noTitle {
 		lines = append(lines, "---")
-		lines = append(lines, fmt.Sprintf("title: %s", c.title))
+		lines = append(lines, internal.FrontMatterTitle(c.title))
 		lines = append(lines, "---")
 	}
 	lines = append(lines, "stateDiagram-v2")

--- a/mermaid/state/state_diagram_test.go
+++ b/mermaid/state/state_diagram_test.go
@@ -53,7 +53,7 @@ func TestDiagram_Build(t *testing.T) {
 		}
 
 		want := `---
-title: Simple State Diagram
+title: "Simple State Diagram"
 ---
 stateDiagram-v2
     [*] --> Still

--- a/scripts/mermaid-check/check.mjs
+++ b/scripts/mermaid-check/check.mjs
@@ -18,6 +18,7 @@ import { createServer } from "node:http";
 import { dirname, join, normalize, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { JSDOM } from "jsdom";
+import { load as parseYAML } from "js-yaml";
 import puppeteer from "puppeteer";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -33,7 +34,9 @@ Object.defineProperty(global, "navigator", {
 });
 
 const mermaid = (await import("mermaid")).default;
-mermaid.initialize({ startOnLoad: false, securityLevel: "loose" });
+// No securityLevel override: the default is "strict", which is what GitHub
+// renders these diagrams with, and the point of this script is to agree with it.
+mermaid.initialize({ startOnLoad: false });
 
 // mermaidBlocks returns every fenced block tagged `mermaid`, with the line
 // number of its first content line. Fences longer than three backticks are
@@ -110,13 +113,16 @@ const rejectedForms = [
 function header(source) {
   const lines = source.split("\n");
   if (lines[0]?.trim() !== "---") {
-    return { frontMatter: [], rest: lines };
+    return { frontMatter: "", rest: lines };
   }
   const end = lines.indexOf("---", 1);
   if (end === -1) {
-    return { frontMatter: [], rest: lines };
+    return { frontMatter: "", rest: lines };
   }
-  return { frontMatter: lines.slice(1, end), rest: lines.slice(end + 1) };
+  return {
+    frontMatter: lines.slice(1, end).join("\n"),
+    rest: lines.slice(end + 1),
+  };
 }
 
 // keyword returns the diagram keyword, e.g. "block" or "stateDiagram-v2".
@@ -142,12 +148,29 @@ function unquote(value) {
 
 // declaredTitle returns the title a diagram asks for: front matter first, then
 // the `title` statement the flat diagram types use.
+//
+// The front matter goes through a YAML parser rather than a regex, because that
+// is what mermaid does with it and the two disagree on exactly the inputs worth
+// catching: `title: Checkout # API` carries a comment, `title: 'Sprint Board'`
+// is quoted, and `title: ~` is not a string at all.
 function declaredTitle(source) {
   const { frontMatter, rest } = header(source);
-  for (const line of frontMatter) {
-    const m = line.match(/^title:\s*(.+)$/);
-    if (m) {
-      return { text: unquote(m[1]), frontMatter: true };
+  if (frontMatter !== "") {
+    let parsed;
+    try {
+      parsed = parseYAML(frontMatter);
+    } catch {
+      // Unparsable front matter is mermaid's error to report, and the render
+      // below reports it.
+      parsed = null;
+    }
+    if (parsed && typeof parsed === "object" && "title" in parsed) {
+      // A null title means YAML read the value as something that is not there:
+      // "~", or a "#" that started a comment instead of the title.
+      if (parsed.title === null || parsed.title === undefined) {
+        return { text: null, frontMatter: true };
+      }
+      return { text: String(parsed.title), frontMatter: true };
     }
   }
   for (const line of rest) {
@@ -161,7 +184,7 @@ function declaredTitle(source) {
 
 // untitledDiagrams are the diagram types whose renderer draws no title at all,
 // in front matter or anywhere else. A `title` statement in one of these is not a
-// title but content: `block` reads it as a row and draws stray blocks labelled
+// title but content: `block` reads it as a row and draws stray blocks labeled
 // "title" and whatever followed it, and `kanban` reads it as a column. Front
 // matter is still allowed, because that form is inert metadata.
 const untitledDiagrams = new Set([
@@ -200,6 +223,12 @@ async function renderer() {
   await new Promise((ready) => server.listen(0, "127.0.0.1", ready));
   const origin = `http://127.0.0.1:${server.address().port}`;
 
+  // --no-sandbox is not a preference: Ubuntu 23.10 and later, which is what the
+  // CI runner and most contributors are on, block the unprivileged user
+  // namespaces Chrome's sandbox needs, and it refuses to start without it. The
+  // exposure is bounded instead: nothing here is fetched from the network, the
+  // browser only ever sees markdown already committed to this repository, and it
+  // renders it at mermaid's default "strict" security level.
   const browser = await puppeteer.launch({
     headless: true,
     executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
@@ -211,7 +240,7 @@ async function renderer() {
     type: "module",
     content: `
       import mermaid from "${origin}/node_modules/mermaid/dist/mermaid.esm.min.mjs";
-      mermaid.initialize({ startOnLoad: false, securityLevel: "loose" });
+      mermaid.initialize({ startOnLoad: false });
       window.draw = async (id, source) => {
         try {
           const { svg } = await mermaid.render(id, source);
@@ -273,6 +302,13 @@ for (const file of await files()) {
 
     const title = declaredTitle(block.body);
     const type = keyword(block.body);
+    if (title && title.text === null) {
+      fail(
+        where,
+        "the front matter declares a title, but YAML reads its value as nothing. Quote it.",
+      );
+      continue;
+    }
     if (title && !title.frontMatter && untitledDiagrams.has(type)) {
       fail(
         where,

--- a/scripts/mermaid-check/check.mjs
+++ b/scripts/mermaid-check/check.mjs
@@ -1,12 +1,26 @@
-// Parse every ```mermaid block in the markdown files given as arguments.
+// Check every ```mermaid block in the markdown files given as arguments.
 //
 // GitHub renders mermaid in the browser, so a diagram this repository generates
-// can be syntactically wrong and still ship: nothing in the Go test suite looks
-// at it, and the failure only appears as an error box on the rendered page.
-// This script runs the real mermaid parser over the committed markdown so a
-// broken diagram fails CI instead.
+// can be wrong and still ship: nothing in the Go test suite looks at it, and the
+// failure only appears on the rendered page. This script puts the committed
+// markdown through the same three failures a reader can hit:
+//
+//  1. parse    - mermaid rejects the source outright.
+//  2. render   - mermaid parses the source but throws while drawing it. GitHub
+//                reports this as "Unable to render rich display"; the parser
+//                alone never sees it, so the render runs in a real browser.
+//  3. meaning  - mermaid renders the source without complaining, but draws
+//                something other than what the builder asked for. A title is the
+//                case this repository has already shipped twice, so a declared
+//                title has to show up in the drawing.
 import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { dirname, join, normalize, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import { JSDOM } from "jsdom";
+import puppeteer from "puppeteer";
+
+const here = dirname(fileURLToPath(import.meta.url));
 
 const dom = new JSDOM("<!doctype html><html><body></body></html>", {
   pretendToBeVisual: true,
@@ -92,30 +106,196 @@ const rejectedForms = [
   },
 ];
 
+// header returns the front matter of a diagram and the source below it.
+function header(source) {
+  const lines = source.split("\n");
+  if (lines[0]?.trim() !== "---") {
+    return { frontMatter: [], rest: lines };
+  }
+  const end = lines.indexOf("---", 1);
+  if (end === -1) {
+    return { frontMatter: [], rest: lines };
+  }
+  return { frontMatter: lines.slice(1, end), rest: lines.slice(end + 1) };
+}
+
+// keyword returns the diagram keyword, e.g. "block" or "stateDiagram-v2".
+function keyword(source) {
+  for (const line of header(source).rest) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("%%")) {
+      continue;
+    }
+    return trimmed.split(/[\s{]/, 1)[0];
+  }
+  return "";
+}
+
+// unquote strips the quoting mermaid accepts around a title.
+function unquote(value) {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+// declaredTitle returns the title a diagram asks for: front matter first, then
+// the `title` statement the flat diagram types use.
+function declaredTitle(source) {
+  const { frontMatter, rest } = header(source);
+  for (const line of frontMatter) {
+    const m = line.match(/^title:\s*(.+)$/);
+    if (m) {
+      return { text: unquote(m[1]), frontMatter: true };
+    }
+  }
+  for (const line of rest) {
+    const m = line.match(/^\s*title\s+(\S.*)$/);
+    if (m) {
+      return { text: unquote(m[1]), frontMatter: false };
+    }
+  }
+  return null;
+}
+
+// untitledDiagrams are the diagram types whose renderer draws no title at all,
+// in front matter or anywhere else. A `title` statement in one of these is not a
+// title but content: `block` reads it as a row and draws stray blocks labelled
+// "title" and whatever followed it, and `kanban` reads it as a column. Front
+// matter is still allowed, because that form is inert metadata.
+const untitledDiagrams = new Set([
+  "block",
+  "block-beta",
+  "architecture-beta",
+  "mindmap",
+  "kanban",
+]);
+
+// renderer runs mermaid in a real browser, because rendering needs the layout
+// and text measurement that jsdom does not implement.
+async function renderer() {
+  const root = resolve(here);
+  const server = createServer((req, res) => {
+    const path = normalize(decodeURIComponent(req.url.split("?")[0]));
+    if (path === "/") {
+      res.setHeader("content-type", "text/html");
+      res.end("<!doctype html><html><body></body></html>");
+      return;
+    }
+    const file = join(root, path);
+    if (!file.startsWith(root + sep)) {
+      res.statusCode = 403;
+      res.end("");
+      return;
+    }
+    try {
+      res.setHeader("content-type", "text/javascript");
+      res.end(readFileSync(file));
+    } catch {
+      res.statusCode = 404;
+      res.end("");
+    }
+  });
+  await new Promise((ready) => server.listen(0, "127.0.0.1", ready));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+
+  const browser = await puppeteer.launch({
+    headless: true,
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
+    args: ["--no-sandbox", "--disable-dev-shm-usage"],
+  });
+  const page = await browser.newPage();
+  await page.goto(origin);
+  await page.addScriptTag({
+    type: "module",
+    content: `
+      import mermaid from "${origin}/node_modules/mermaid/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: false, securityLevel: "loose" });
+      window.draw = async (id, source) => {
+        try {
+          const { svg } = await mermaid.render(id, source);
+          const host = document.createElement("div");
+          host.innerHTML = svg;
+          document.body.appendChild(host);
+          const text = host.textContent;
+          host.remove();
+          return { text };
+        } catch (e) {
+          return { error: String((e && e.message) || e) };
+        }
+      };
+      window.ready = true;`,
+  });
+  await page.waitForFunction("window.ready === true", { timeout: 60000 });
+
+  let id = 0;
+  return {
+    draw: (source) =>
+      page.evaluate((name, text) => window.draw(name, text), `diagram-${id++}`, source),
+    close: async () => {
+      await browser.close();
+      server.close();
+    },
+  };
+}
+
+const draw = await renderer();
 let checked = 0;
 let failed = 0;
+
+const fail = (where, message) => {
+  failed++;
+  console.error(`${where}: ${message}\n`);
+};
 
 for (const file of await files()) {
   for (const block of mermaidBlocks(readFileSync(file, "utf8"))) {
     checked++;
+    const where = `${file}:${block.line}`;
+
     for (const form of rejectedForms) {
       if (form.pattern.test(block.body)) {
-        failed++;
-        console.error(`${file}:${block.line}: ${form.reason}\n`);
+        fail(where, form.reason);
       }
     }
+
     try {
       await mermaid.parse(block.body);
     } catch (e) {
-      failed++;
       const message = (e && e.message ? e.message : String(e))
         .split("\n")
         .slice(0, 8)
         .join("\n");
-      console.error(`${file}:${block.line}: mermaid parse error\n${message}\n`);
+      fail(where, `mermaid parse error\n${message}`);
+      continue;
+    }
+
+    const title = declaredTitle(block.body);
+    const type = keyword(block.body);
+    if (title && !title.frontMatter && untitledDiagrams.has(type)) {
+      fail(
+        where,
+        `a "${type}" diagram has no title statement; mermaid reads "title ${title.text}" as diagram content. Move it to the front matter.`,
+      );
+      continue;
+    }
+
+    const drawn = await draw.draw(block.body);
+    if (drawn.error) {
+      fail(where, `mermaid render error\n${drawn.error}`);
+      continue;
+    }
+    if (title && !untitledDiagrams.has(type) && !drawn.text.includes(title.text)) {
+      fail(
+        where,
+        `the title "${title.text}" is declared but does not appear in the rendered diagram`,
+      );
     }
   }
 }
+
+await draw.close();
 
 console.log(`checked ${checked} mermaid block(s), ${failed} failed`);
 if (checked === 0) {

--- a/scripts/mermaid-check/package-lock.json
+++ b/scripts/mermaid-check/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "jsdom": "^28.0.0",
-        "mermaid": "^11.16.1"
+        "mermaid": "^11.16.1",
+        "puppeteer": "^25.6.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -274,6 +275,34 @@
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.2"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.0.tgz",
+      "integrity": "sha512-LlBrE8oqGfU7b1Nk2d5Q1SbuPhZxTj0cJEMDPEws28OjNMELlflekmPPuf4FnK03x0ZRjKaYwJElUcKK4kyqJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/d3": {
@@ -561,6 +590,30 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -568,6 +621,53 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/commander": {
@@ -1166,6 +1266,12 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1653615",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
+      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/dompurify": {
       "version": "3.4.13",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
@@ -1174,6 +1280,12 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -1197,6 +1309,36 @@
         "benchmarks",
         "tests/types"
       ]
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
@@ -1355,6 +1497,18 @@
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lodash-es": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
@@ -1417,6 +1571,21 @@
         "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1470,6 +1639,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.6.0.tgz",
+      "integrity": "sha512-TXUolDddU4AwISjOOrGk2AhJDpbM/ZDt2KvGIqz74EOk+8bKwXFo+acUvP1sQx3hUda7owOeNuuT1UnJT1o0qA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.2.0",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.6.0",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.6.0.tgz",
+      "integrity": "sha512-GJ67rjZdVQzZmD2Ab0cgttfQN9j387QYMv3t6MN3/4nmjursNt6M5Utj4/T/4y0AwNrSwJzjw6Q/zuWFEIizOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.2.0",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/require-from-string": {
@@ -1530,6 +1737,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/stylis": {
@@ -1604,6 +1842,12 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
@@ -1638,6 +1882,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -1670,6 +1920,61 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -1684,6 +1989,50 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/scripts/mermaid-check/package-lock.json
+++ b/scripts/mermaid-check/package-lock.json
@@ -8,6 +8,7 @@
       "name": "markdown-mermaid-check",
       "version": "0.0.0",
       "dependencies": {
+        "js-yaml": "^5.2.3",
         "jsdom": "^28.0.0",
         "mermaid": "^11.16.1",
         "puppeteer": "^25.6.0"
@@ -613,6 +614,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -1420,6 +1427,28 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
     },
     "node_modules/jsdom": {
       "version": "28.1.0",

--- a/scripts/mermaid-check/package.json
+++ b/scripts/mermaid-check/package.json
@@ -9,6 +9,7 @@
     "test": "node selftest.mjs"
   },
   "dependencies": {
+    "js-yaml": "^5.2.3",
     "jsdom": "^28.0.0",
     "mermaid": "^11.16.1",
     "puppeteer": "^25.6.0"

--- a/scripts/mermaid-check/package.json
+++ b/scripts/mermaid-check/package.json
@@ -2,13 +2,15 @@
   "name": "markdown-mermaid-check",
   "version": "0.0.0",
   "private": true,
-  "description": "Parses the mermaid diagrams committed in this repository so a broken one fails CI.",
+  "description": "Renders the mermaid diagrams committed in this repository so a broken one fails CI.",
   "type": "module",
   "scripts": {
-    "check": "node check.mjs"
+    "check": "node check.mjs",
+    "test": "node selftest.mjs"
   },
   "dependencies": {
     "jsdom": "^28.0.0",
-    "mermaid": "^11.16.1"
+    "mermaid": "^11.16.1",
+    "puppeteer": "^25.6.0"
   }
 }

--- a/scripts/mermaid-check/selftest.mjs
+++ b/scripts/mermaid-check/selftest.mjs
@@ -1,0 +1,63 @@
+// Run check.mjs over the fixtures in testdata/ and assert it reports what it
+// should. A checker that stops catching anything looks exactly like a checker
+// with nothing to catch, so the guard needs a guard.
+//
+// The fixtures use the .mdfixture extension on purpose: they are broken by
+// design, and a *.md name would sweep them into the repository-wide run.
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = (name) => join(here, "testdata", name);
+
+const cases = [
+  {
+    file: "block-title-statement.mdfixture",
+    expect: 'a "block" diagram has no title statement',
+  },
+  {
+    file: "kanban-title-statement.mdfixture",
+    expect: 'a "kanban" diagram has no title statement',
+  },
+  {
+    file: "class-standalone-annotation.mdfixture",
+    expect: "standalone class annotation",
+  },
+  {
+    file: "unparsable.mdfixture",
+    expect: "mermaid parse error",
+  },
+  {
+    file: "valid.mdfixture",
+    expect: null,
+  },
+];
+
+let failed = 0;
+for (const c of cases) {
+  const run = spawnSync(process.execPath, [join(here, "check.mjs"), fixture(c.file)], {
+    encoding: "utf8",
+  });
+  const output = `${run.stdout}${run.stderr}`;
+
+  if (c.expect === null) {
+    if (run.status !== 0) {
+      failed++;
+      console.error(`${c.file}: expected a clean run, got:\n${output}`);
+    }
+    continue;
+  }
+  if (run.status === 0) {
+    failed++;
+    console.error(`${c.file}: expected a failure mentioning ${JSON.stringify(c.expect)}, got a clean run`);
+    continue;
+  }
+  if (!output.includes(c.expect)) {
+    failed++;
+    console.error(`${c.file}: expected ${JSON.stringify(c.expect)} in:\n${output}`);
+  }
+}
+
+console.log(`self test: ${cases.length} fixture(s), ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/scripts/mermaid-check/selftest.mjs
+++ b/scripts/mermaid-check/selftest.mjs
@@ -29,6 +29,14 @@ const cases = [
     expect: "mermaid parse error",
   },
   {
+    file: "frontmatter-unquoted-colon.mdfixture",
+    expect: "mermaid parse error",
+  },
+  {
+    file: "frontmatter-comment-title.mdfixture",
+    expect: "YAML reads its value as nothing",
+  },
+  {
     file: "valid.mdfixture",
     expect: null,
   },

--- a/scripts/mermaid-check/testdata/block-title-statement.mdfixture
+++ b/scripts/mermaid-check/testdata/block-title-statement.mdfixture
@@ -1,0 +1,8 @@
+# Fixture: a block diagram with an in-body title
+
+```mermaid
+block
+    title Checkout Architecture
+    columns 2
+    Frontend Backend
+```

--- a/scripts/mermaid-check/testdata/class-standalone-annotation.mdfixture
+++ b/scripts/mermaid-check/testdata/class-standalone-annotation.mdfixture
@@ -1,0 +1,6 @@
+# Fixture: a class diagram with a standalone annotation
+
+```mermaid
+classDiagram
+    <<Interface>> PaymentGateway
+```

--- a/scripts/mermaid-check/testdata/frontmatter-comment-title.mdfixture
+++ b/scripts/mermaid-check/testdata/frontmatter-comment-title.mdfixture
@@ -1,0 +1,9 @@
+# Fixture: a title YAML swallows as a comment
+
+```mermaid
+---
+title: # Checkout
+---
+flowchart TB
+    A-->B
+```

--- a/scripts/mermaid-check/testdata/frontmatter-unquoted-colon.mdfixture
+++ b/scripts/mermaid-check/testdata/frontmatter-unquoted-colon.mdfixture
@@ -1,0 +1,9 @@
+# Fixture: a title YAML cannot read as a plain scalar
+
+```mermaid
+---
+title: Checkout: API
+---
+flowchart TB
+    A-->B
+```

--- a/scripts/mermaid-check/testdata/kanban-title-statement.mdfixture
+++ b/scripts/mermaid-check/testdata/kanban-title-statement.mdfixture
@@ -1,0 +1,8 @@
+# Fixture: a kanban board with an in-body title
+
+```mermaid
+kanban
+    title Sprint Board
+    [Todo]
+        [Define scope]
+```

--- a/scripts/mermaid-check/testdata/unparsable.mdfixture
+++ b/scripts/mermaid-check/testdata/unparsable.mdfixture
@@ -1,0 +1,6 @@
+# Fixture: a diagram mermaid cannot parse
+
+```mermaid
+flowchart TB
+    A --> 
+```

--- a/scripts/mermaid-check/testdata/valid.mdfixture
+++ b/scripts/mermaid-check/testdata/valid.mdfixture
@@ -1,0 +1,18 @@
+# Fixture: everything below renders the way it reads
+
+```mermaid
+---
+title: Checkout Domain
+---
+classDiagram
+    class Order
+```
+
+```mermaid
+---
+title: Checkout Architecture
+---
+block
+    columns 2
+    Frontend Backend
+```


### PR DESCRIPTION
## Summary

The block diagram builder emitted its title as a `title X` statement inside the diagram body, but `block` has no title statement in mermaid: the line is read as a row, so the README drew stray blocks labelled "title", "Checkout" and "Architecture" above the real diagram. The title now goes in the front matter, and the render check that was supposed to catch this is extended so the whole class of failure fails CI.

## Changes

- `mermaid/block/block_diagram.go`: emit the title as front matter (`---` / `title: X` / `---`) ahead of the `block` keyword, the way every other builder here does it.
- `mermaid/block/config.go`, `mermaid/mindmap/config.go`, `mermaid/kanban/config.go`: document on `WithTitle` that mermaid's renderer for these three diagram types keeps the title as metadata and never draws it.
- `README.md`, `doc/block/generated.md`, `mermaid/block/*_test.go`: the regenerated output and the expectations that pin it.
- `scripts/mermaid-check/check.mjs`: draw every committed diagram with the real mermaid renderer in headless Chrome, on top of the existing parse, and report a declared title that never reaches the drawing.
- `scripts/mermaid-check/selftest.mjs`, `scripts/mermaid-check/testdata/`: fixtures that assert the checker still catches each failure it is meant to catch.
- `.github/workflows/doc_render.yml`, `Makefile`, `CONTRIBUTING.md`: run the renderer and its self test, with the puppeteer Chrome download cached.

## Design Decisions

`WithTitle` is kept rather than removed. Front matter is valid mermaid and is what the rest of this repository emits, so the option keeps working the day mermaid teaches the block renderer to draw a title, and today it at least stops corrupting the diagram instead of quietly dropping the call on the floor.

Parsing was never going to catch this. `title Checkout Architecture` is a perfectly valid block row, so `mermaid.parse` accepted it and the diagram shipped drawing the wrong thing. The check now renders in a browser and compares a declared title against the text that actually lands in the SVG, which is what turned up mindmap and kanban as the same shape of problem. Diagram types whose renderer draws no title at all are listed explicitly, and for those a `title` statement (as opposed to front matter) is reported, because that is the form that becomes content.

The fixtures use a `.mdfixture` extension so that files which are broken on purpose cannot be swept into the repository-wide `git ls-files '*.md'` run.

## Limitations

Front matter titles on `block`, `mindmap` and `kanban` diagrams are still invisible to readers. That is mermaid's renderer, not this package, and the godoc now says so.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Mermaid diagram titles now use standardized, safely quoted YAML front matter.
  - Validation checks both parsing and browser rendering, including title behavior, with actionable file and line diagnostics.
  - Clarified that titles may not be visibly rendered in block, kanban, and mindmap diagrams; use diagram content for reader-visible wording.
- **Documentation**
  - Updated Mermaid examples and generated documentation to reflect the new title format.
  - Added contribution guidance for regenerating and rendering documentation after Mermaid builder changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->