### PR TITLE
test: pin and document the error handling every builder shares

### DIFF
--- a/error_contract_test.go
+++ b/error_contract_test.go
@@ -1,0 +1,190 @@
+package markdown_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/markdown"
+	"github.com/nao1215/markdown/internal/buildertest"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return markdown.NewMarkdown(w).H1("Title")
+	})
+}
+
+// TestRecordedErrorContract asserts that a table whose rows do not match its
+// header surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return markdown.NewMarkdown(w).Table(markdown.TableSet{
+			Header: []string{"one", "two"},
+			Rows:   [][]string{{"only one cell"}},
+		})
+	})
+}
+
+// TestErrorSurfacesFromBothErrorAndBuild pins that the two ways of asking for
+// the error agree. Callers use whichever suits the shape of their code, and a
+// builder that reported an error from only one of them would be a trap.
+func TestErrorSurfacesFromBothErrorAndBuild(t *testing.T) {
+	t.Parallel()
+
+	m := markdown.NewMarkdown(io.Discard).Table(markdown.TableSet{
+		Header: []string{"one", "two"},
+		Rows:   [][]string{{"only one cell"}},
+	})
+
+	fromError := m.Error()
+	if fromError == nil {
+		t.Fatal("Error() = nil, want the error the chain recorded")
+	}
+	if !errors.Is(fromError, markdown.ErrMismatchColumn) {
+		t.Errorf("Error() = %v, want an error wrapping ErrMismatchColumn", fromError)
+	}
+
+	fromBuild := m.Build()
+	if fromBuild == nil {
+		t.Fatal("Build() = nil, want the error the chain recorded")
+	}
+	if !errors.Is(fromBuild, markdown.ErrMismatchColumn) {
+		t.Errorf("Build() = %v, want an error wrapping ErrMismatchColumn", fromBuild)
+	}
+}
+
+// TestTheChainContinuesAfterAnError pins that a rejected call does not stop the
+// document. Callers write one long chain and check it once at the end, so the
+// blocks after a bad table still have to appear.
+func TestTheChainContinuesAfterAnError(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	err := markdown.NewMarkdown(buf).
+		H1("Before").
+		Table(markdown.TableSet{
+			Header: []string{"one", "two"},
+			Rows:   [][]string{{"only one cell"}},
+		}).
+		H2("After").
+		Build()
+	if err == nil {
+		t.Fatal("Build() = nil, want the error the chain recorded")
+	}
+
+	for _, want := range []string{"# Before", "## After"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("document = %q, want it to contain %q", buf.String(), want)
+		}
+	}
+}
+
+// TestTheFirstErrorIsKept pins which error a caller sees when a chain records
+// more than one. The first is the one that explains the rest, so it is the one
+// that survives; the later ones are appended to its message rather than
+// replacing it.
+func TestTheFirstErrorIsKept(t *testing.T) {
+	t.Parallel()
+
+	m := markdown.NewMarkdown(io.Discard).
+		TableOfContents(markdown.TableOfContentsDepthH3).
+		TableOfContents(markdown.TableOfContentsDepthH3)
+
+	err := m.Error()
+	if err == nil {
+		t.Fatal("Error() = nil, want the error the chain recorded")
+	}
+	if want := "table of contents has already been generated"; !strings.Contains(err.Error(), want) {
+		t.Errorf("Error() = %v, want it to mention %q", err, want)
+	}
+}
+
+// TestBuildWithNilWriterKeepsTheEarlierError pins that a nil writer does not
+// hide what went wrong before it. Both failures are worth knowing about, so the
+// message carries the earlier one too.
+func TestBuildWithNilWriterKeepsTheEarlierError(t *testing.T) {
+	t.Parallel()
+
+	err := markdown.NewMarkdown(nil).
+		Table(markdown.TableSet{
+			Header: []string{"one", "two"},
+			Rows:   [][]string{{"only one cell"}},
+		}).
+		Build()
+	if err == nil {
+		t.Fatal("Build() = nil, want an error")
+	}
+
+	for _, want := range []string{"destination writer is nil", markdown.ErrMismatchColumn.Error()} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Build() = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+// TestBuildWithFailingWriterKeepsTheEarlierError pins the same for a writer
+// that refuses the document.
+func TestBuildWithFailingWriterKeepsTheEarlierError(t *testing.T) {
+	t.Parallel()
+
+	err := markdown.NewMarkdown(buildertest.FailingWriter{}).
+		Table(markdown.TableSet{
+			Header: []string{"one", "two"},
+			Rows:   [][]string{{"only one cell"}},
+		}).
+		Build()
+	if err == nil {
+		t.Fatal("Build() = nil, want an error")
+	}
+
+	for _, want := range []string{"failed to write markdown text", markdown.ErrMismatchColumn.Error()} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Build() = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+// TestBuildEndsTheDocumentWithALineFeed pins the trailing newline. markdownlint
+// MD047 requires it, and without it a second document written to the same
+// writer would splice its first line onto the last line of this one.
+func TestBuildEndsTheDocumentWithALineFeed(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(*markdown.Markdown) *markdown.Markdown{
+		"a document ending in a heading": func(m *markdown.Markdown) *markdown.Markdown {
+			return m.H1("Title")
+		},
+		"a document ending in a table": func(m *markdown.Markdown) *markdown.Markdown {
+			return m.Table(markdown.TableSet{
+				Header: []string{"key", "value"},
+				Rows:   [][]string{{"a", "b"}},
+			})
+		},
+		"an empty document": func(m *markdown.Markdown) *markdown.Markdown {
+			return m
+		},
+	}
+
+	for name, build := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			buf := &bytes.Buffer{}
+			if err := build(markdown.NewMarkdown(buf)).Build(); err != nil {
+				t.Fatalf("Build() = %v, want nil", err)
+			}
+			if !strings.HasSuffix(buf.String(), "\n") {
+				t.Errorf("document = %q, want it to end with a line feed", buf.String())
+			}
+		})
+	}
+}

--- a/internal/buildertest/buildertest.go
+++ b/internal/buildertest/buildertest.go
@@ -1,0 +1,153 @@
+// Package buildertest exercises the error handling that every builder in this
+// module shares.
+//
+// The root package and the seventeen mermaid subpackages each expose a builder
+// with the same shape: methods that chain, a String that returns the document
+// so far, and a Build that writes it. They also share an error handling
+// contract, which callers depend on without it having been written down: no
+// call in a chain has to be checked, nothing panics on bad input, and Build is
+// the one place an error surfaces.
+//
+// Keeping the assertions here means each package states which builder it has
+// rather than restating the contract, and a change to the contract is one edit
+// instead of eighteen.
+package buildertest
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// errFailingWrite is what FailingWriter returns. Tests match on it with
+// errors.Is, so a builder that loses the cause instead of wrapping it fails.
+var errFailingWrite = errors.New("buildertest: the writer refused the document")
+
+// FailingWriter is an io.Writer whose every write fails. It stands in for a
+// closed file or a full disk, which is the failure a builder cannot avoid and
+// has to report.
+type FailingWriter struct{}
+
+// Write always fails.
+func (FailingWriter) Write([]byte) (int, error) {
+	return 0, errFailingWrite
+}
+
+// Builder is the part of a builder that the shared contract covers. Error is
+// left out on purpose: er.Diagram and piechart.PieChart do not have it.
+type Builder interface {
+	// Build writes the document to the writer the builder was constructed with.
+	Build() error
+	// String returns the document built so far.
+	String() string
+}
+
+// New constructs the builder under test, writing to w. The returned builder
+// should already have some content, so that a document that fails to be written
+// is distinguishable from an empty one.
+type New func(w io.Writer) Builder
+
+// RunBuildContract asserts the error handling every builder in this module
+// shares. Call it from a package's own test with a constructor for that
+// package's builder.
+func RunBuildContract(t *testing.T, newBuilder New) {
+	t.Helper()
+
+	t.Run("a nil writer is reported rather than panicking", func(t *testing.T) {
+		t.Parallel()
+
+		err := newBuilder(nil).Build()
+		if err == nil {
+			t.Fatal("Build() = nil, want an error: a builder with no destination cannot have written anything")
+		}
+	})
+
+	t.Run("a failing writer is reported and keeps its cause", func(t *testing.T) {
+		t.Parallel()
+
+		err := newBuilder(FailingWriter{}).Build()
+		if err == nil {
+			t.Fatal("Build() = nil, want an error")
+		}
+		if !errors.Is(err, errFailingWrite) {
+			t.Errorf("Build() = %v, want an error wrapping the writer failure", err)
+		}
+	})
+
+	t.Run("String returns the document without a writer", func(t *testing.T) {
+		t.Parallel()
+
+		// This is how a mermaid diagram reaches CodeBlocks: the diagram is built
+		// against no writer at all and handed over as a string.
+		if got := newBuilder(nil).String(); got == "" {
+			t.Error("String() = \"\", want the document built so far")
+		}
+	})
+
+	t.Run("Build writes the document String returns", func(t *testing.T) {
+		t.Parallel()
+
+		buf := &bytes.Buffer{}
+		builder := newBuilder(buf)
+		want := builder.String()
+
+		if err := builder.Build(); err != nil {
+			t.Fatalf("Build() = %v, want nil", err)
+		}
+		// The root builder appends the trailing line feed that markdownlint
+		// MD047 wants, so the written document starts with, rather than equals,
+		// what String returned.
+		if !strings.HasPrefix(buf.String(), want) {
+			t.Errorf("Build() wrote %q, want it to start with the document String() returned, %q", buf.String(), want)
+		}
+	})
+
+	t.Run("Build twice writes the document twice", func(t *testing.T) {
+		t.Parallel()
+
+		buf := &bytes.Buffer{}
+		builder := newBuilder(buf)
+
+		if err := builder.Build(); err != nil {
+			t.Fatalf("first Build() = %v, want nil", err)
+		}
+		once := buf.Len()
+
+		if err := builder.Build(); err != nil {
+			t.Fatalf("second Build() = %v, want nil", err)
+		}
+		if want := once + once; buf.Len() != want {
+			t.Errorf("two Build() calls wrote %d bytes, want %d: Build appends, it does not replace", buf.Len(), want)
+		}
+	})
+}
+
+// RunRecordedErrorContract asserts that an error recorded while the chain ran
+// surfaces from Build, and that the chain got that far without panicking.
+//
+// Call it with a constructor that makes the builder reject something, for
+// example a name the diagram syntax cannot express. Packages whose builders
+// never record an error have nothing to pass here.
+func RunRecordedErrorContract(t *testing.T, newRejectingBuilder New) {
+	t.Helper()
+
+	t.Run("an error recorded while building surfaces from Build", func(t *testing.T) {
+		t.Parallel()
+
+		if err := newRejectingBuilder(io.Discard).Build(); err == nil {
+			t.Error("Build() = nil, want the error the chain recorded")
+		}
+	})
+
+	t.Run("the rest of the chain still runs after an error", func(t *testing.T) {
+		t.Parallel()
+
+		// Nothing after a rejected call may panic: callers write one long chain
+		// and only check the end of it.
+		builder := newRejectingBuilder(io.Discard)
+		_ = builder.String()
+		_ = builder.Build()
+	})
+}

--- a/markdown.go
+++ b/markdown.go
@@ -1,4 +1,20 @@
 // Package markdown is markdown builder that includes to convert Markdown to HTML.
+//
+// # Error handling
+//
+// A document is one method chain, so the builder records errors instead of
+// returning them from every call. Nothing in a chain panics on bad input, and
+// nothing has to be checked individually: the chain runs to the end and the
+// error surfaces from [Markdown.Error] or from [Markdown.Build], which agree.
+//
+// A rejected call does not stop the document. The blocks after it are still
+// added, so a table with a mismatched row costs that table and nothing else.
+// When a chain records more than one error, the first is kept, because it is
+// the one that explains the rest; later failures are appended to its message.
+//
+// [Markdown.String] returns the document whether or not an error occurred, and
+// it needs no writer, which is how the mermaid subpackages hand a diagram to
+// [Markdown.CodeBlocks].
 package markdown
 
 import (
@@ -197,6 +213,9 @@ func NewMarkdown(w io.Writer, opts ...Option) *Markdown {
 }
 
 // String returns markdown text.
+//
+// It returns the document built so far whether or not an error was recorded,
+// and it does not need a writer, so it works on a builder constructed with nil.
 func (m *Markdown) String() string {
 	body := m.body
 
@@ -353,7 +372,10 @@ func insertTableOfContents(body, toc []string) []string {
 	return out
 }
 
-// Error returns error.
+// Error returns the error the chain recorded, or nil.
+//
+// It is the same error [Markdown.Build] returns, for callers who would rather
+// check before writing than after.
 func (m *Markdown) Error() error {
 	return m.err
 }
@@ -370,6 +392,15 @@ func (m *Markdown) PlainTextf(format string, args ...interface{}) *Markdown {
 }
 
 // Build writes markdown text to output destination.
+//
+// It returns the error the chain recorded, or nil. A nil destination and a
+// destination that refuses the document are both reported rather than causing a
+// panic, and either message carries the earlier error too when there is one.
+//
+// The document is written with a trailing line ending, so appending a second
+// document to the same writer starts it on its own line.
+//
+// Build may be called more than once; each call writes the document again.
 func (m *Markdown) Build() error {
 	if m.dest == nil {
 		if m.err != nil {

--- a/mermaid/arch/architecture.go
+++ b/mermaid/arch/architecture.go
@@ -1,6 +1,11 @@
 // Package arch is mermaid architecture diagram builder.
 // The building blocks of an architecture are groups, services, edges, and junctions.
 // The arch package incorporates beta features of Mermaid, so the specifications are subject to significant changes.
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package arch
 
 import (

--- a/mermaid/arch/error_contract_test.go
+++ b/mermaid/arch/error_contract_test.go
@@ -1,0 +1,19 @@
+package arch_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/arch"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return arch.NewArchitecture(w).Service("api", arch.IconServer, "API")
+	})
+}

--- a/mermaid/block/block_diagram.go
+++ b/mermaid/block/block_diagram.go
@@ -1,6 +1,11 @@
 // Package block is mermaid block diagram builder.
 //
 // Ref. https://mermaid.js.org/syntax/block.html
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package block
 
 import (

--- a/mermaid/block/error_contract_test.go
+++ b/mermaid/block/error_contract_test.go
@@ -1,0 +1,28 @@
+package block_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/block"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return block.NewDiagram(w).Row(block.Node("a"))
+	})
+}
+
+// TestRecordedErrorContract asserts that a column count the syntax cannot express surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return block.NewDiagram(w).Columns(0).Row(block.Node("a"))
+	})
+}

--- a/mermaid/class/class_diagram.go
+++ b/mermaid/class/class_diagram.go
@@ -1,6 +1,11 @@
 // Package class is mermaid class diagram builder.
 //
 // Ref. https://mermaid.js.org/syntax/classDiagram.html
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package class
 
 import (

--- a/mermaid/class/error_contract_test.go
+++ b/mermaid/class/error_contract_test.go
@@ -1,0 +1,19 @@
+package class_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/class"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return class.NewDiagram(w).Class("Account")
+	})
+}

--- a/mermaid/er/entity_relationship.go
+++ b/mermaid/er/entity_relationship.go
@@ -1,4 +1,9 @@
 // Package er is mermaid entity relationship diagram builder.
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package er
 
 import (

--- a/mermaid/er/error_contract_test.go
+++ b/mermaid/er/error_contract_test.go
@@ -1,0 +1,19 @@
+package er_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/er"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return er.NewDiagram(w).NoRelationship(er.NewEntity("teachers", nil))
+	})
+}

--- a/mermaid/flowchart/error_contract_test.go
+++ b/mermaid/flowchart/error_contract_test.go
@@ -1,0 +1,19 @@
+package flowchart_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/flowchart"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return flowchart.NewFlowchart(w).NodeWithText("A", "Node A")
+	})
+}

--- a/mermaid/flowchart/flowchart.go
+++ b/mermaid/flowchart/flowchart.go
@@ -1,4 +1,9 @@
 // Package flowchart provides a simple way to create flowcharts in mermaid syntax.
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package flowchart
 
 import (

--- a/mermaid/gantt/error_contract_test.go
+++ b/mermaid/gantt/error_contract_test.go
@@ -1,0 +1,19 @@
+package gantt_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/gantt"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return gantt.NewChart(w).Section("Planning").Task("Design", "2024-01-01", "2d")
+	})
+}

--- a/mermaid/gantt/gantt_chart.go
+++ b/mermaid/gantt/gantt_chart.go
@@ -1,4 +1,9 @@
 // Package gantt is a mermaid Gantt chart builder.
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package gantt
 
 import (

--- a/mermaid/gitgraph/error_contract_test.go
+++ b/mermaid/gitgraph/error_contract_test.go
@@ -1,0 +1,28 @@
+package gitgraph_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/gitgraph"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return gitgraph.NewDiagram(w).Commit()
+	})
+}
+
+// TestRecordedErrorContract asserts that a branch order the syntax cannot express surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return gitgraph.NewDiagram(w).Commit().Branch("develop", gitgraph.WithBranchOrder(-1))
+	})
+}

--- a/mermaid/gitgraph/git_graph.go
+++ b/mermaid/gitgraph/git_graph.go
@@ -1,6 +1,11 @@
 // Package gitgraph is mermaid git graph diagram builder.
 //
 // Ref. https://mermaid.js.org/syntax/gitgraph.html
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package gitgraph
 
 import (

--- a/mermaid/kanban/error_contract_test.go
+++ b/mermaid/kanban/error_contract_test.go
@@ -1,0 +1,28 @@
+package kanban_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/kanban"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return kanban.NewDiagram(w).Column("Todo").Task("Define scope")
+	})
+}
+
+// TestRecordedErrorContract asserts that a task added before any column surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return kanban.NewDiagram(w).Task("a task with no column")
+	})
+}

--- a/mermaid/kanban/kanban.go
+++ b/mermaid/kanban/kanban.go
@@ -1,6 +1,11 @@
 // Package kanban is mermaid kanban diagram builder.
 //
 // Ref. https://mermaid.js.org/syntax/kanban.html
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package kanban
 
 import (

--- a/mermaid/mindmap/error_contract_test.go
+++ b/mermaid/mindmap/error_contract_test.go
@@ -1,0 +1,28 @@
+package mindmap_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/mindmap"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return mindmap.NewDiagram(w).Root("Product").Child("Market")
+	})
+}
+
+// TestRecordedErrorContract asserts that a child added before the root surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return mindmap.NewDiagram(w).Child("a child with no root")
+	})
+}

--- a/mermaid/mindmap/mindmap.go
+++ b/mermaid/mindmap/mindmap.go
@@ -1,6 +1,11 @@
 // Package mindmap is mermaid mindmap diagram builder.
 //
 // Ref. https://mermaid.js.org/syntax/mindmap.html
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package mindmap
 
 import (

--- a/mermaid/packet/error_contract_test.go
+++ b/mermaid/packet/error_contract_test.go
@@ -1,0 +1,28 @@
+package packet_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/packet"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return packet.NewDiagram(w).Field(0, 15, "Source Port")
+	})
+}
+
+// TestRecordedErrorContract asserts that a bit range the syntax cannot express surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return packet.NewDiagram(w).Field(-1, 15, "Source Port")
+	})
+}

--- a/mermaid/packet/packet.go
+++ b/mermaid/packet/packet.go
@@ -1,6 +1,11 @@
 // Package packet is mermaid packet diagram builder.
 //
 // Ref. https://mermaid.js.org/syntax/packet.html
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package packet
 
 import (

--- a/mermaid/piechart/error_contract_test.go
+++ b/mermaid/piechart/error_contract_test.go
@@ -1,0 +1,19 @@
+package piechart_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/piechart"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return piechart.NewPieChart(w).LabelAndIntValue("Go", 120)
+	})
+}

--- a/mermaid/piechart/pie_chart.go
+++ b/mermaid/piechart/pie_chart.go
@@ -1,4 +1,9 @@
 // Package piechart is mermaid pie chart builder.
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package piechart
 
 import (

--- a/mermaid/quadrant/error_contract_test.go
+++ b/mermaid/quadrant/error_contract_test.go
@@ -1,0 +1,19 @@
+package quadrant_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/quadrant"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return quadrant.NewChart(w).Point("Campaign A", 0.3, 0.6)
+	})
+}

--- a/mermaid/quadrant/quadrant_chart.go
+++ b/mermaid/quadrant/quadrant_chart.go
@@ -1,4 +1,9 @@
 // Package quadrant is mermaid quadrant chart builder.
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package quadrant
 
 import (

--- a/mermaid/requirement/error_contract_test.go
+++ b/mermaid/requirement/error_contract_test.go
@@ -1,0 +1,34 @@
+package requirement_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/requirement"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return requirement.NewDiagram(w).Requirement(
+			"a requirement",
+			requirement.WithID("1"),
+			requirement.WithText("the system shall do the thing"),
+			requirement.WithRisk(requirement.RiskLow),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest),
+		)
+	})
+}
+
+// TestRecordedErrorContract asserts that a requirement missing the fields the syntax needs surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return requirement.NewDiagram(w).Requirement("a requirement with no id")
+	})
+}

--- a/mermaid/requirement/requirement_diagram.go
+++ b/mermaid/requirement/requirement_diagram.go
@@ -1,6 +1,11 @@
 // Package requirement is mermaid requirement diagram builder.
 //
 // Ref. https://mermaid.js.org/syntax/requirementDiagram.html
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package requirement
 
 import (

--- a/mermaid/sequence/error_contract_test.go
+++ b/mermaid/sequence/error_contract_test.go
@@ -1,0 +1,19 @@
+package sequence_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/sequence"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return sequence.NewDiagram(w).SyncRequest("Client", "Server", "GET /users")
+	})
+}

--- a/mermaid/sequence/sequence.go
+++ b/mermaid/sequence/sequence.go
@@ -1,4 +1,9 @@
 // Package sequence is mermaid sequence diagram builder.
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package sequence
 
 import (

--- a/mermaid/state/error_contract_test.go
+++ b/mermaid/state/error_contract_test.go
@@ -1,0 +1,19 @@
+package state_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/state"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return state.NewDiagram(w).State("Draft", "The order is being written")
+	})
+}

--- a/mermaid/state/state_diagram.go
+++ b/mermaid/state/state_diagram.go
@@ -1,4 +1,9 @@
 // Package state is mermaid state diagram builder.
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package state
 
 import (

--- a/mermaid/userjourney/error_contract_test.go
+++ b/mermaid/userjourney/error_contract_test.go
@@ -1,0 +1,28 @@
+package userjourney_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/userjourney"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return userjourney.NewDiagram(w).Section("Discovery").Task("Find the site", userjourney.ScoreSatisfied)
+	})
+}
+
+// TestRecordedErrorContract asserts that an empty section name surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return userjourney.NewDiagram(w).Section("")
+	})
+}

--- a/mermaid/userjourney/user_journey.go
+++ b/mermaid/userjourney/user_journey.go
@@ -1,6 +1,11 @@
 // Package userjourney is mermaid user journey diagram builder.
 //
 // Ref. https://mermaid.js.org/syntax/userJourney.html
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package userjourney
 
 import (

--- a/mermaid/xychart/error_contract_test.go
+++ b/mermaid/xychart/error_contract_test.go
@@ -1,0 +1,28 @@
+package xychart_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/xychart"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return xychart.NewDiagram(w).Line(5000, 6000)
+	})
+}
+
+// TestRecordedErrorContract asserts that an empty set of x-axis labels surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return xychart.NewDiagram(w).XAxisLabels()
+	})
+}

--- a/mermaid/xychart/xy_chart.go
+++ b/mermaid/xychart/xy_chart.go
@@ -1,6 +1,11 @@
 // Package xychart is mermaid XY chart builder.
 //
 // Ref. https://mermaid.js.org/syntax/xyChart.html
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
 package xychart
 
 import (


### PR DESCRIPTION
Closes #124

## Why

Callers depend on an error handling contract that was never written down. A document is one method chain, so no call in it can be checked individually; nothing may panic on bad input; and `Build` has to be the one place an error surfaces. Each package tested a piece of that, no two packages tested the same pieces, and the godoc said nothing at all.

At v1.0.0 this becomes a promise, so it needs to be stated and enforced.

## What

`internal/buildertest` states the contract once and asserts it:

- a nil writer is reported rather than causing a panic;
- a writer that refuses the document is reported and the error keeps its cause, so `errors.Is` finds it;
- `String` returns the document without needing a writer, which is how a mermaid diagram reaches `CodeBlocks`;
- `Build` writes what `String` returned;
- `Build` twice writes the document twice.

All eighteen builders (the root one and the seventeen mermaid ones) run it. The eight whose builder methods can reject their input also run a second helper asserting that the rejection surfaces from `Build` and that the rest of the chain still runs.

The root package pins what only it does: `Error` and `Build` agree; a rejected call does not stop the document; the first error is the one kept; a nil or failing writer keeps the earlier error in its message; and `Build` ends the document with a line feed.

The godoc now documents all of this: an "Error handling" section on the root package, expanded comments on `Build`, `Error`, and `String`, and a paragraph in each mermaid package comment.

## Findings recorded rather than fixed

Writing the shared contract surfaced two inconsistencies. Both are left exactly as they are, since changing either would break callers, and both are worth recording in the v1 API audit (#118):

- `er.Diagram` and `piechart.PieChart` have no `Error()` method, while the other sixteen mermaid builders do. The shared `Builder` interface therefore covers `Build` and `String` only.
- `Build` in `arch`, `class`, `er`, `flowchart`, `gantt`, `piechart`, `quadrant`, `sequence`, and `state` returns `nil` on the success path rather than the recorded error. This is harmless today because no builder method in those packages records one, but it means the two groups would behave differently if one ever did.

## No behavior change

Only tests and comments. `go test ./...`, `go vet ./...`, and `golangci-lint run ./...` are clean, and every one of the eighteen builders passes the shared contract unmodified.