### PR TITLE
fix: link to markdown files relative to the index, using URL separators

### DIFF
--- a/index.go
+++ b/index.go
@@ -139,15 +139,40 @@ func (i *Index) write() (err error) {
 		markdown.H3(subTitle)
 
 		for _, f := range markdownFiles {
+			link := i.linkTo(f)
 			if h1 := firstH1orH2(f); h1 != "" {
-				markdown.BulletList(Link(h1, strings.Replace(f, i.targetDir+string(filepath.Separator), "", 1)))
+				markdown.BulletList(Link(h1, link))
 				continue
 			}
-			markdown.BulletList(Link(filepath.Base(f), strings.Replace(f, i.targetDir+string(filepath.Separator), "", 1)))
+			markdown.BulletList(Link(filepath.Base(f), link))
 		}
 		markdown.LF()
 	}
 	return markdown.Build()
+}
+
+// linkTo returns the destination of the link to the markdown file at path,
+// relative to the generated index.
+//
+// Two things have to hold for the link to work. It has to be relative to the
+// index, which sits in the target directory, and it has to use "/", because a
+// markdown link destination is a URL: a backslash in one is an escape character
+// rather than a directory separator, so a link built from a Windows path points
+// nowhere.
+//
+// Trimming the target directory as a string prefix did neither. It kept the
+// whole path whenever the caller wrote the target with forward slashes on
+// Windows, or with a trailing separator anywhere, because the prefix it built
+// then matched nothing.
+//
+// A path that cannot be made relative to the target directory is used as it is.
+// That is the version the caller passed in, so it is the one they recognize.
+func (i *Index) linkTo(path string) string {
+	rel, err := filepath.Rel(i.targetDir, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
 }
 
 // hasDir checks if the index has a directory.

--- a/index_test.go
+++ b/index_test.go
@@ -131,3 +131,58 @@ func TestGenerateIndexClosesFile(t *testing.T) {
 		t.Fatalf("failed to remove generated index file: %v", err)
 	}
 }
+
+// TestGenerateIndexLinksAreRelativeURLs pins the destinations the generated
+// index links to.
+//
+// Two things have to hold for a link to work. It has to be relative to the
+// index, which sits in the target directory, and it has to use "/", because a
+// markdown link destination is a URL and a backslash in one is an escape
+// character rather than a directory separator.
+//
+// The target directory is given in several shapes because callers write paths
+// the way that reads best in Go source, which is usually with forward slashes
+// even on Windows.
+func TestGenerateIndexLinksAreRelativeURLs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	docs := filepath.Join(root, "docs")
+	if err := os.MkdirAll(filepath.Join(docs, "sub"), 0750); err != nil {
+		t.Fatalf("failed to create the fixture tree: %v", err)
+	}
+	for path, content := range map[string]string{
+		filepath.Join(docs, "guide.md"):         "# Guide\n",
+		filepath.Join(docs, "sub", "nested.md"): "# Nested\n",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write the fixture %s: %v", path, err)
+		}
+	}
+
+	tests := map[string]string{
+		"the platform separator": docs,
+		"a trailing separator":   docs + string(filepath.Separator),
+		"forward slashes":        filepath.ToSlash(docs),
+	}
+
+	for name, targetDir := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			if err := GenerateIndex(targetDir, WithWriter(&buf)); err != nil {
+				t.Fatalf("failed to generate index: %v", err)
+			}
+
+			for _, want := range []string{"[Guide](guide.md)", "[Nested](sub/nested.md)"} {
+				if !strings.Contains(buf.String(), want) {
+					t.Errorf("index = %q, want it to contain %q", buf.String(), want)
+				}
+			}
+			if strings.Contains(buf.String(), `\`) {
+				t.Errorf("index = %q, want no backslash: a link destination is a URL", buf.String())
+			}
+		})
+	}
+}

--- a/testdata/index/expected/index.windows
+++ b/testdata/index/expected/index.windows
@@ -7,15 +7,15 @@ Next Description
 - [test.md](test.md)
   
 ### abc
-- [h2 is here](abc\test.md)
+- [h2 is here](abc/test.md)
   
 ### jkl
-- [text.md](abc\jkl\text.md)
+- [text.md](abc/jkl/text.md)
   
 ### def
-- [h2 is first, not h1](def\test.md)
-- [h1 is here](def\test2.md)
+- [h2 is first, not h1](def/test.md)
+- [h1 is here](def/test2.md)
   
 ### expected
-- [Test Title](expected\index.md)
+- [Test Title](expected/index.md)
   


### PR DESCRIPTION
Closes #136

## The bug

`GenerateIndex` built each link by trimming the target directory off the walked path as a string prefix:

```go
strings.Replace(f, i.targetDir+string(filepath.Separator), "", 1)
```

`godirwalk` returns paths with the platform separator. So when a caller wrote the target the ordinary way in Go source, with forward slashes, the prefix on Windows became `docs/api\` and matched nothing: every link kept the full path and the generated `index.md` pointed nowhere. A trailing separator broke it the same way on every platform, since the prefix then had two separators in a row. Neither case returned an error.

There is a second half to it. A markdown link destination is a URL, not a path, so a backslash in one is an escape character rather than a directory separator. Even when the prefix did come off, links generated on Windows were `sub\nested.md`, which no renderer resolves.

Found by the Windows job on #135, where the fixture directory was written as `testdata/index`.

## The fix

`filepath.Rel` computes the relative path whatever shape the caller gave the target in, and `filepath.ToSlash` turns the result into a URL. A path that cannot be made relative is used as it is, which is the version the caller passed in and the one they will recognize.

## Behavior change

The generated links change on Windows. That is allowed under the output stability rule because the links being replaced do not resolve: the output was objectively broken. Linux and macOS output is unchanged, which the golden files and the existing index fixture confirm.

`testdata/index/expected/index.windows` is updated accordingly, and it is now exactly the CRLF twin of the Linux fixture, which it should have been all along.

## Tests

`TestGenerateIndexLinksAreRelativeURLs` builds a temporary tree and generates the index with the target directory written three ways: with the platform separator, with a trailing separator, and with forward slashes. It asserts the exact link destinations and that no backslash appears anywhere in the output.

Verified that it fails against the old implementation: the trailing separator case reproduces the bug on Linux, printing absolute paths as link destinations. The forward slash case is the one that reproduces it on Windows.

## Signature

`GenerateIndex` and every option keep their signatures.