### PR TITLE
feat(mermaid): add timeline diagram support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 The markdown package is a simple markdown builder for Go. It assembles a document by method chaining instead of through a template engine such as [html/template](https://pkg.go.dev/html/template), and the syntax it emits follows GitHub Markdown.
 
-It also builds mermaid diagrams: entity relationship, sequence, user journey, git graph, mindmap, requirement, xy chart, packet, block, kanban, flowchart, pie chart, quadrant, state, class, Gantt, and architecture. That came from the package's origin, which was saving test results for [nao1215/spectest](https://github.com/nao1215/spectest).
+It also builds mermaid diagrams: entity relationship, sequence, user journey, git graph, mindmap, requirement, xy chart, packet, block, kanban, flowchart, pie chart, quadrant, state, class, Gantt, architecture, and timeline. That came from the package's origin, which was saving test results for [nao1215/spectest](https://github.com/nao1215/spectest).
 
 Anything that would make the library complicated, such as generating nested lists, is out of scope. Staying simple matters more here.
 
@@ -58,6 +58,7 @@ Anything that would make the library complicated, such as generating nested list
 - [x] mermaid class diagram
 - [x] mermaid Gantt chart
 - [x] mermaid architecture diagram (beta feature) 
+- [x] mermaid timeline diagram
 
 ### Features not in Markdown syntax
 - Generate badges; RedBadge(), YellowBadge(), GreenBadge().
@@ -1833,6 +1834,81 @@ gantt
     Review :review, after code, 2d
     section Release
     Launch :milestone, launch, 2024-01-26, 0d
+```
+
+### Timeline syntax
+
+```go
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/nao1215/markdown"
+	"github.com/nao1215/markdown/mermaid/timeline"
+)
+
+//go:generate go run main.go
+
+func main() {
+	f, err := os.Create("generated.md")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	diagram := timeline.NewDiagram(
+		io.Discard,
+		timeline.WithTitle("History of Social Media"),
+	).
+		Period("2002", "LinkedIn").
+		Section("Second wave").
+		Period("2004", "Facebook", "Google").
+		Period("2005", "YouTube").
+		Section("Third wave").
+		Period("2006", "Twitter").
+		Event("Reddit").
+		String()
+
+	err = markdown.NewMarkdown(f).
+		H2("Timeline").
+		CodeBlocks(markdown.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	if err != nil {
+		panic(err)
+	}
+}
+```
+
+A period holds as many events as you give it, and `Event` adds one more to the period written last. A colon in any text is emitted as `&#58;`, because a colon is what separates a period from its events; it reaches the reader as a colon either way, so `Period("09:00", "Stand up")` says what it looks like.
+
+Plain text output: [markdown is here](./doc/timeline/generated.md)
+````
+## Timeline
+```mermaid
+timeline
+    title History of Social Media
+    2002 : LinkedIn
+    section Second wave
+        2004 : Facebook : Google
+        2005 : YouTube
+    section Third wave
+        2006 : Twitter : Reddit
+```
+````
+
+Mermaid output:
+```mermaid
+timeline
+    title History of Social Media
+    2002 : LinkedIn
+    section Second wave
+        2004 : Facebook : Google
+        2005 : YouTube
+    section Third wave
+        2006 : Twitter : Reddit
 ```
 
 ## Creating an index for a directory full of markdown files

--- a/doc/timeline/generated.md
+++ b/doc/timeline/generated.md
@@ -1,0 +1,12 @@
+## Timeline
+
+```mermaid
+timeline
+    title History of Social Media
+    2002 : LinkedIn
+    section Second wave
+        2004 : Facebook : Google
+        2005 : YouTube
+    section Third wave
+        2006 : Twitter : Reddit
+```

--- a/doc/timeline/main.go
+++ b/doc/timeline/main.go
@@ -1,0 +1,49 @@
+//go:build linux || darwin
+
+// Package main is generating mermaid timeline diagram.
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/nao1215/markdown"
+	"github.com/nao1215/markdown/mermaid/timeline"
+)
+
+// This file is gated by //go:build linux || darwin, so //go:generate is skipped
+// on Windows. To regenerate generated.md on Windows, run under WSL or via CI.
+//go:generate go run main.go
+
+func main() {
+	f, err := os.Create("generated.md")
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	diagram := timeline.NewDiagram(
+		io.Discard,
+		timeline.WithTitle("History of Social Media"),
+	).
+		Period("2002", "LinkedIn").
+		Section("Second wave").
+		Period("2004", "Facebook", "Google").
+		Period("2005", "YouTube").
+		Section("Third wave").
+		Period("2006", "Twitter").
+		Event("Reddit").
+		String()
+
+	err = markdown.NewMarkdown(f, markdown.WithBlockSpacing()).
+		H2("Timeline").
+		CodeBlocks(markdown.SyntaxHighlightMermaid, diagram).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/mermaid/timeline/config.go
+++ b/mermaid/timeline/config.go
@@ -1,0 +1,33 @@
+package timeline
+
+// noTitle is a constant for no title.
+const noTitle string = ""
+
+// config is the configuration for the timeline diagram.
+type config struct {
+	// title is the title of the timeline diagram.
+	title string
+}
+
+// newConfig returns a new config with default values.
+func newConfig() *config {
+	return &config{
+		title: noTitle,
+	}
+}
+
+// Option sets the options for the Diagram struct.
+type Option func(*config)
+
+// WithTitle sets the title configuration.
+//
+// The title is emitted as a title statement rather than as front matter,
+// because mermaid's timeline renderer draws the former and keeps the latter as
+// metadata a reader never sees. A title statement reads to the end of the line,
+// so the punctuation that breaks a period line, a colon above all, is safe in
+// one.
+func WithTitle(title string) Option {
+	return func(c *config) {
+		c.title = title
+	}
+}

--- a/mermaid/timeline/error_contract_test.go
+++ b/mermaid/timeline/error_contract_test.go
@@ -1,0 +1,29 @@
+package timeline_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/buildertest"
+	"github.com/nao1215/markdown/mermaid/timeline"
+)
+
+// TestBuildContract asserts the error handling every builder in this module
+// shares. The contract itself lives in internal/buildertest.
+func TestBuildContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunBuildContract(t, func(w io.Writer) buildertest.Builder {
+		return timeline.NewDiagram(w).Period("2002", "LinkedIn")
+	})
+}
+
+// TestRecordedErrorContract asserts that an event written before any period
+// surfaces from Build.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return timeline.NewDiagram(w).Event("an event with no period")
+	})
+}

--- a/mermaid/timeline/examples_test.go
+++ b/mermaid/timeline/examples_test.go
@@ -1,0 +1,44 @@
+//go:build linux || darwin
+
+package timeline_test
+
+import (
+	"io"
+	"os"
+
+	md "github.com/nao1215/markdown"
+	"github.com/nao1215/markdown/mermaid/timeline"
+)
+
+// ExampleDiagram skips this test on Windows.
+// The newline codes in the comment section where
+// the expected values are written are represented as '\n',
+// causing failures when testing on Windows.
+func ExampleDiagram() {
+	diagram := timeline.NewDiagram(
+		io.Discard,
+		timeline.WithTitle("History of Social Media"),
+	).
+		Period("2002", "LinkedIn").
+		Section("Second wave").
+		Period("2004", "Facebook", "Google").
+		Period("2005", "YouTube").
+		Event("Reddit").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Timeline").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Timeline
+	// ```mermaid
+	// timeline
+	//     title History of Social Media
+	//     2002 : LinkedIn
+	//     section Second wave
+	//         2004 : Facebook : Google
+	//         2005 : YouTube : Reddit
+	// ```
+}

--- a/mermaid/timeline/golden_test.go
+++ b/mermaid/timeline/golden_test.go
@@ -1,0 +1,35 @@
+package timeline_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nao1215/markdown/internal/golden"
+	"github.com/nao1215/markdown/mermaid/timeline"
+)
+
+// TestGoldenTimeline pins the rendered diagram of every builder method and
+// every option of this package.
+func TestGoldenTimeline(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	err := timeline.NewDiagram(buf, timeline.WithTitle("History of Social Media")).
+		Period("2002", "LinkedIn").
+		Section("Second wave").
+		Period("2004", "Facebook", "Google").
+		Event("Flickr").
+		Period("2005", "YouTube").
+		LF().
+		Section("Third wave").
+		Period("2006", "Twitter").
+		Period("09:00 stand up").
+		Build()
+	if err != nil {
+		t.Fatalf("Build() = %v, want nil", err)
+	}
+
+	if err := golden.Assert("timeline.md", buf.String()); err != nil {
+		t.Error(err)
+	}
+}

--- a/mermaid/timeline/testdata/golden/timeline.md
+++ b/mermaid/timeline/testdata/golden/timeline.md
@@ -1,0 +1,10 @@
+timeline
+    title History of Social Media
+    2002 : LinkedIn
+    section Second wave
+        2004 : Facebook : Google : Flickr
+        2005 : YouTube
+
+    section Third wave
+        2006 : Twitter
+        09&#58;00 stand up

--- a/mermaid/timeline/timeline.go
+++ b/mermaid/timeline/timeline.go
@@ -1,0 +1,238 @@
+// Package timeline is mermaid timeline diagram builder.
+//
+// Ref. https://mermaid.js.org/syntax/timeline.html
+//
+// A timeline is a list of time periods, each holding one or more events, and
+// optionally grouped into sections. A period is written once and its events
+// follow it, so the builder mirrors that: Period starts one, and Event adds to
+// whichever period is current.
+//
+// Errors are recorded rather than returned from every call: the chain runs to
+// the end and the error surfaces from Build. A nil writer and a writer that
+// refuses the diagram are both reported rather than causing a panic, and
+// String returns the diagram without needing a writer at all.
+package timeline
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+const (
+	// timelineLinesCap is the number of lines a small timeline starts with.
+	timelineLinesCap int = 8
+	// statementIndent is the indent of a statement directly under "timeline".
+	statementIndent = "    "
+	// sectionIndent is the indent of a period inside a section.
+	sectionIndent = "        "
+	// colonEntity is the HTML entity for a colon.
+	//
+	// A colon separates a period from its events, and mermaid's timeline syntax
+	// has no escape for one in the text. It renders the text as HTML, so the
+	// entity reaches the reader as a colon while the parser never sees one.
+	colonEntity = "&#58;"
+)
+
+// Diagram is a timeline diagram builder.
+type Diagram struct {
+	// body is the timeline diagram body.
+	body []string
+	// dest is the output destination for the timeline diagram body.
+	dest io.Writer
+	// err manages errors that occur in all parts of the diagram building.
+	err error
+	// inSection reports whether a section has been opened, which decides how
+	// far a period is indented.
+	inSection bool
+	// hasPeriod reports whether a period has been written, which is what an
+	// event needs in order to have somewhere to go.
+	hasPeriod bool
+}
+
+// NewDiagram returns a new Diagram.
+func NewDiagram(w io.Writer, opts ...Option) *Diagram {
+	c := newConfig()
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	trimmedTitle := strings.TrimSpace(c.title)
+	if containsNewline(trimmedTitle) {
+		return &Diagram{
+			body: []string{"timeline"},
+			dest: w,
+			err:  errors.New("title must not contain newline characters"),
+		}
+	}
+
+	lines := make([]string, 0, timelineLinesCap)
+	lines = append(lines, "timeline")
+	if trimmedTitle != noTitle {
+		// A title statement reads to the end of the line, so the text goes in
+		// as it is; the newline that would end it early is refused above.
+		lines = append(lines, statementIndent+"title "+trimmedTitle)
+	}
+
+	return &Diagram{
+		body: lines,
+		dest: w,
+	}
+}
+
+// String returns the timeline diagram body.
+func (d *Diagram) String() string {
+	return strings.Join(d.body, internal.LineFeed())
+}
+
+// Error returns the error that occurred during the timeline diagram building.
+func (d *Diagram) Error() error {
+	return d.err
+}
+
+// Build writes the timeline diagram body to the output destination.
+func (d *Diagram) Build() error {
+	if d.err != nil {
+		return d.err
+	}
+	if d.dest == nil {
+		d.err = errors.New("output writer must not be nil")
+		return d.err
+	}
+
+	if _, err := fmt.Fprint(d.dest, d.String()); err != nil {
+		d.err = fmt.Errorf("failed to write: %w", err)
+		return d.err
+	}
+	return nil
+}
+
+// LF adds a line feed to the timeline diagram body.
+func (d *Diagram) LF() *Diagram {
+	if d.err != nil {
+		return d
+	}
+	d.body = append(d.body, "")
+	return d
+}
+
+// Section starts a section, which groups the periods that follow it.
+//
+// A timeline needs no sections at all; periods written before the first one
+// stand on their own.
+func (d *Diagram) Section(name string) *Diagram {
+	if d.err != nil {
+		return d
+	}
+
+	text, err := validateText("section name", name)
+	if err != nil {
+		d.setError(err)
+		return d
+	}
+
+	d.inSection = true
+	d.hasPeriod = false
+	d.body = append(d.body, statementIndent+"section "+text)
+	return d
+}
+
+// Period adds a time period and the events that belong to it.
+//
+// The period is what a reader sees on the axis, so it is usually a year or a
+// date, but mermaid does not require that: any text will do. Events may also be
+// added afterwards with Event.
+func (d *Diagram) Period(period string, events ...string) *Diagram {
+	if d.err != nil {
+		return d
+	}
+
+	text, err := validateText("period", period)
+	if err != nil {
+		d.setError(err)
+		return d
+	}
+
+	var line strings.Builder
+	line.WriteString(d.periodIndent())
+	line.WriteString(text)
+	for i, event := range events {
+		eventText, err := validateText(fmt.Sprintf("event %d of period %q", i+1, period), event)
+		if err != nil {
+			d.setError(err)
+			return d
+		}
+		line.WriteString(" : ")
+		line.WriteString(eventText)
+	}
+
+	d.hasPeriod = true
+	d.body = append(d.body, line.String())
+	return d
+}
+
+// Event adds an event to the period Period opened last.
+//
+// Period must be called before Event; otherwise an error is recorded, because
+// an event with no period has nowhere to go on the axis.
+func (d *Diagram) Event(event string) *Diagram {
+	if d.err != nil {
+		return d
+	}
+	if !d.hasPeriod {
+		d.setError(fmt.Errorf("event %q requires a period; call Period first", event))
+		return d
+	}
+
+	text, err := validateText("event", event)
+	if err != nil {
+		d.setError(err)
+		return d
+	}
+
+	d.body[len(d.body)-1] += " : " + text
+	return d
+}
+
+// periodIndent returns the indent a period is written at, which is one level
+// deeper inside a section.
+func (d *Diagram) periodIndent() string {
+	if d.inSection {
+		return sectionIndent
+	}
+	return statementIndent
+}
+
+// setError records the first error and leaves any later one alone, because the
+// first is the one that explains the rest.
+func (d *Diagram) setError(err error) {
+	if d.err == nil {
+		d.err = err
+	}
+}
+
+// validateText returns value ready to be written into the diagram.
+//
+// A newline ends a statement and a colon separates a period from its events, so
+// neither can be carried through as it is. The newline is rejected, because a
+// timeline entry is a single line by construction and silently joining the
+// lines would say something the caller did not. The colon becomes an entity,
+// which reaches the reader unchanged.
+func validateText(fieldName, value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("%s must not be empty", fieldName)
+	}
+	if containsNewline(trimmed) {
+		return "", fmt.Errorf("%s must not contain newline characters", fieldName)
+	}
+	return strings.ReplaceAll(trimmed, ":", colonEntity), nil
+}
+
+// containsNewline reports whether value holds a line ending of either kind.
+func containsNewline(value string) bool {
+	return strings.ContainsAny(value, "\n\r")
+}

--- a/mermaid/timeline/timeline_test.go
+++ b/mermaid/timeline/timeline_test.go
@@ -1,0 +1,248 @@
+package timeline_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/markdown/mermaid/timeline"
+)
+
+func TestDiagram(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(w io.Writer) *timeline.Diagram
+		want  []string
+	}{
+		"a bare timeline": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w)
+			},
+			want: []string{"timeline"},
+		},
+		"a title": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w, timeline.WithTitle("History of social media"))
+			},
+			want: []string{"timeline", "    title History of social media"},
+		},
+		"a title is trimmed": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w, timeline.WithTitle("   spaced   "))
+			},
+			want: []string{"timeline", "    title spaced"},
+		},
+		"a title holding a colon stays as it is": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w, timeline.WithTitle("History: the sequel"))
+			},
+			// A title statement reads to the end of the line, so a colon in one
+			// is not the separator it is on a period line.
+			want: []string{"timeline", "    title History: the sequel"},
+		},
+		"a period with one event": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("2002", "LinkedIn")
+			},
+			want: []string{"timeline", "    2002 : LinkedIn"},
+		},
+		"a period with several events": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("2004", "Facebook", "Google")
+			},
+			want: []string{"timeline", "    2004 : Facebook : Google"},
+		},
+		"a period with no events at all": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("2002")
+			},
+			want: []string{"timeline", "    2002"},
+		},
+		"events added afterwards": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).
+					Period("2004", "Facebook").
+					Event("Google").
+					Event("Flickr")
+			},
+			want: []string{"timeline", "    2004 : Facebook : Google : Flickr"},
+		},
+		"a section indents the periods under it": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).
+					Period("2002", "LinkedIn").
+					Section("Second wave").
+					Period("2004", "Facebook").
+					Period("2005", "YouTube")
+			},
+			want: []string{
+				"timeline",
+				"    2002 : LinkedIn",
+				"    section Second wave",
+				"        2004 : Facebook",
+				"        2005 : YouTube",
+			},
+		},
+		"a colon in a period becomes an entity": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("09:00", "Stand up")
+			},
+			// The parser would read a bare colon as the separator, so the period
+			// would silently become an event of an empty period.
+			want: []string{"timeline", "    09&#58;00 : Stand up"},
+		},
+		"a colon in an event becomes an entity": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("2004", "Launch: phase one").Event("Review: phase two")
+			},
+			want: []string{"timeline", "    2004 : Launch&#58; phase one : Review&#58; phase two"},
+		},
+		"a colon in a section name becomes an entity": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Section("Phase: one")
+			},
+			want: []string{"timeline", "    section Phase&#58; one"},
+		},
+		"text is trimmed": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("  2002  ", "  LinkedIn  ")
+			},
+			want: []string{"timeline", "    2002 : LinkedIn"},
+		},
+		"a line feed": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("2002", "LinkedIn").LF().Period("2004", "Facebook")
+			},
+			want: []string{"timeline", "    2002 : LinkedIn", "", "    2004 : Facebook"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			buf := &bytes.Buffer{}
+			if err := tt.build(buf).Build(); err != nil {
+				t.Fatalf("Build() = %v, want nil", err)
+			}
+
+			want := strings.Join(tt.want, "\n")
+			got := strings.ReplaceAll(buf.String(), "\r\n", "\n")
+			if got != want {
+				t.Errorf("diagram =\n%s\nwant\n%s", got, want)
+			}
+		})
+	}
+}
+
+func TestDiagramRejectsWhatItCannotWrite(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(w io.Writer) *timeline.Diagram
+		want  string
+	}{
+		"a title holding a newline": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w, timeline.WithTitle("first\nsecond"))
+			},
+			want: "title must not contain newline characters",
+		},
+		"a period holding a newline": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("first\nsecond", "event")
+			},
+			want: "period must not contain newline characters",
+		},
+		"an event holding a newline": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("2002", "first\nsecond")
+			},
+			want: "must not contain newline characters",
+		},
+		"an appended event holding a carriage return": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("2002", "one").Event("first\rsecond")
+			},
+			want: "event must not contain newline characters",
+		},
+		"a section holding a newline": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Section("first\nsecond")
+			},
+			want: "section name must not contain newline characters",
+		},
+		"an empty period": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("   ")
+			},
+			want: "period must not be empty",
+		},
+		"an empty event": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("2002", "  ")
+			},
+			want: "must not be empty",
+		},
+		"an empty section name": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Section("")
+			},
+			want: "section name must not be empty",
+		},
+		"an event with no period": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Event("orphan")
+			},
+			want: `event "orphan" requires a period`,
+		},
+		"an event after a section that has no period yet": {
+			build: func(w io.Writer) *timeline.Diagram {
+				return timeline.NewDiagram(w).Period("2002", "one").Section("next").Event("orphan")
+			},
+			want: `event "orphan" requires a period`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			d := tt.build(io.Discard)
+
+			err := d.Build()
+			if err == nil {
+				t.Fatal("Build() = nil, want an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("Build() = %v, want it to mention %q", err, tt.want)
+			}
+			if d.Error() == nil {
+				t.Error("Error() = nil, want the same error Build returned")
+			}
+		})
+	}
+}
+
+// TestTheFirstErrorIsKept pins that a chain records the error that explains the
+// rest, and that the calls after it change nothing.
+func TestTheFirstErrorIsKept(t *testing.T) {
+	t.Parallel()
+
+	d := timeline.NewDiagram(io.Discard).
+		Period("").
+		Section("").
+		Period("2002", "LinkedIn").
+		LF().
+		Event("Later")
+
+	err := d.Error()
+	if err == nil {
+		t.Fatal("Error() = nil, want an error")
+	}
+	if want := "period must not be empty"; !strings.Contains(err.Error(), want) {
+		t.Errorf("Error() = %v, want it to mention %q", err, want)
+	}
+}


### PR DESCRIPTION
Closes #126

## What

`mermaid/timeline` builds mermaid timeline diagrams. A timeline is a list of time periods, each holding one or more events and optionally grouped into sections, so the builder mirrors that shape: `Period` starts one and `Event` adds to whichever period is current.

```go
timeline.NewDiagram(io.Discard, timeline.WithTitle("History of Social Media")).
    Period("2002", "LinkedIn").
    Section("Second wave").
    Period("2004", "Facebook", "Google").
    Period("2005", "YouTube").
    Event("Reddit").
    String()
```

The API follows `mermaid/kanban`: `NewDiagram(w io.Writer, opts ...Option)`, chainable methods, `Build`, `Error`, `String`, `LF`, and `WithXxx` options.

## Two decisions worth stating

**The title is a title statement, not front matter.** The issue said to follow kanban, which writes its title into front matter. I rendered both: mermaid's timeline renderer draws a title statement and keeps front matter as metadata a reader never sees. A title statement also reads to the end of the line, so the punctuation that breaks a period line is safe in one. Verified with mermaid-cli.

**A colon becomes `&#58;`.** A colon separates a period from its events, and the syntax has no escape for one in the text. Without encoding it, `Period("09:00", "Stand up")` silently becomes an event of an empty period, which parses and renders and is wrong. mermaid renders timeline text as HTML, so the entity reaches the reader as a colon while the parser never sees one. Verified by rendering.

A line break is refused rather than encoded, because a timeline entry is one line by construction and joining the lines would say something the caller did not.

## Tests

`go test ./mermaid/timeline/` reports **100% of statements**.

- `timeline_test.go`: table driven, asserting exact output for every method, every option, the colon encoding in a period, an event and a section name, and the indent a section adds.
- A second table for everything the builder refuses: newlines in a title, period, event or section, empty text of each kind, an event with no period, and an event after a section that has no period yet. Each asserts that `Error` and `Build` agree.
- `error_contract_test.go`: the shared builder contract from `internal/buildertest`.
- `golden_test.go`: the whole diagram, pinned.
- `examples_test.go`: an output-verified godoc example.

## Rendering

`doc/timeline/main.go` generates a committed sample, which the render job draws with the real mermaid renderer. Verified locally: the sample renders, and so does the README's copy of it.

The edge case documents from #125 are not extended here because that pull request has not merged yet. Once it does, `timeline` belongs in `supported` there; from the probing done for #146 it takes every character in the set except a line break.

## Scope

Additive only. Nothing outside `mermaid/timeline/`, `doc/timeline/`, and `README.md` changed.