### PR TITLE
docs: state what a mermaid title that is not valid UTF-8 does

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -63,6 +63,7 @@ Raising the `go` directive is a minor release, not a major one, because it does 
 
 These are contracts rather than accidents, and are covered by tests:
 
+- Text handed to a builder is expected to be valid UTF-8. A mermaid diagram title that is not valid UTF-8 still produces a diagram and still produces parseable YAML front matter, but each byte outside a valid UTF-8 sequence is read back as the code point of that byte: a title holding the single byte `0xC9` is written as `"\xc9"` and reads as `É`. YAML is defined over Unicode, so such a title has no faithful representation in it; the diagram is kept rather than the exact bytes.
 - A builder records the errors it encounters while the chain runs and returns them from `Error` and from `Build`. Nothing in the chain panics on bad input, and no call has to be checked individually.
 - `Build` with a nil writer returns an error rather than panicking.
 - `String` returns the document built so far whether or not an error occurred, so it works on a builder that never had a writer. This is how the `mermaid/*` subpackages hand a diagram to `CodeBlocks`.

--- a/contract_test.go
+++ b/contract_test.go
@@ -1087,13 +1087,6 @@ func FuzzFrontMatterTitle(f *testing.F) {
 			// which is a different property and is covered by the unit tests.
 			return
 		}
-		if !utf8.ValidString(title) {
-			// YAML is defined over Unicode, so a title that is not valid UTF-8
-			// has no faithful representation in it. See the note on this target
-			// in the pull request that added it.
-			return
-		}
-
 		diagram := flowchart.NewFlowchart(io.Discard, flowchart.WithTitle(title)).
 			NodeWithText("A", "Node A").
 			String()
@@ -1109,10 +1102,38 @@ func FuzzFrontMatterTitle(f *testing.F) {
 		if err := yaml.Unmarshal([]byte(block), &parsed); err != nil {
 			t.Fatalf("the front matter of the diagram built with title %q is not valid YAML: %v\n%s", title, err, block)
 		}
-		if parsed.Title != title {
-			t.Errorf("the front matter title parsed as %q, want %q", parsed.Title, title)
+		if want := asYAMLReadsIt(title); parsed.Title != want {
+			t.Errorf("the front matter title parsed as %q, want %q", parsed.Title, want)
 		}
 	})
+}
+
+// asYAMLReadsIt returns the title a YAML parser reads back out of the front
+// matter this library writes for it.
+//
+// It is the identity for every title that is valid UTF-8, which is every title
+// a caller has. Below that the two disagree in one specific way, documented in
+// SPEC.md: strconv.Quote writes a byte no valid UTF-8 sequence covers as \xNN,
+// meaning that byte, and YAML reads \xNN as the code point U+00NN. Spelling the
+// disagreement out here rather than skipping those inputs is what keeps the
+// fuzzer able to find a second one.
+func asYAMLReadsIt(title string) string {
+	if utf8.ValidString(title) {
+		return title
+	}
+
+	var b strings.Builder
+	for i := 0; i < len(title); {
+		r, size := utf8.DecodeRuneInString(title[i:])
+		if r == utf8.RuneError && size == 1 {
+			b.WriteRune(rune(title[i]))
+			i++
+			continue
+		}
+		b.WriteString(title[i : i+size])
+		i += size
+	}
+	return b.String()
 }
 
 // frontMatter returns the body between the first two "---" lines of a diagram.

--- a/internal/frontmatter.go
+++ b/internal/frontmatter.go
@@ -26,6 +26,19 @@ func FrontMatterTitle(title string) string {
 // the replacements misses the control characters that have no shorthand, and a
 // literal control character inside a quoted scalar is a parse error, which loses
 // the whole diagram rather than mangling one line of it.
+//
+// The two forms agree for every title that is valid UTF-8, which is every title
+// a caller has. They part company below that: strconv.Quote writes a byte that
+// no valid UTF-8 sequence covers as \xNN, meaning that byte, and YAML reads
+// \xNN as the code point U+00NN. A title holding the single byte 0xC9 is written
+// as "\xc9" and read back as "É".
+//
+// That is left alone deliberately. YAML is defined over Unicode, so a byte
+// string that is not UTF-8 has no faithful representation in it, and every way
+// out mangles the title one way or another: replacing the byte with U+FFFD
+// loses it just as thoroughly and changes bytes this library has already
+// shipped. Reinterpretation at least keeps the diagram, keeps the front matter
+// parseable, and is documented in SPEC.md rather than being a surprise.
 func quoteYAML(value string) string {
 	return strconv.Quote(value)
 }

--- a/internal/frontmatter_test.go
+++ b/internal/frontmatter_test.go
@@ -103,6 +103,15 @@ func TestFrontMatterTitle(t *testing.T) {
 			want:  `title: "Café ☕"`,
 		},
 		{
+			// A byte no valid UTF-8 sequence covers is written as \xNN and read
+			// back by a YAML parser as U+00NN, so this title reaches the drawing
+			// as "É". SPEC.md documents that; what is pinned here is that the
+			// front matter stays parseable rather than losing the diagram.
+			name:  "a byte that is not valid UTF-8 is escaped rather than written raw",
+			title: "Caf\xc9",
+			want:  `title: "Caf\xc9"`,
+		},
+		{
 			name:  "empty title",
 			title: "",
 			want:  `title: ""`,


### PR DESCRIPTION
Closes #144.

## The finding

`internal.FrontMatterTitle` quotes with `strconv.Quote`, which writes a byte that no valid UTF-8 sequence covers as `\xNN`, meaning *that byte*. YAML reads `\xNN` as *the code point U+00NN*. A title holding the single byte `0xC9` is written as `"\xc9"` and reaches the drawing as `É`. `FuzzFrontMatterTitle` found this and skipped past it.

## The decision

Option 1 from the issue: keep the behavior, document it.

YAML is defined over Unicode, so a byte string that is not UTF-8 has no faithful representation in it. Replacing the byte with U+FFFD loses the character just as thoroughly, and it would change bytes this library has already shipped for an input that is out of contract either way — which the output-stability rule in `SPEC.md` reserves for output that is objectively broken. This output is not: the diagram draws and the front matter parses. What is lost is one title's characters, on an input no ordinary caller has.

## Changes

- `SPEC.md` gains a known-behavior entry saying text is expected to be valid UTF-8 and what happens when a title is not.
- `internal/frontmatter.go` carries the reasoning next to the code, including why U+FFFD was not chosen and why the quoter is not hand rolled.
- A unit test pins that the byte is escaped rather than written raw, which is the part that keeps the scalar parseable.
- `FuzzFrontMatterTitle` no longer skips invalid UTF-8. It asserts the round trip against an oracle that spells the reinterpretation out, so a *second* way for a title to come back wrong still fails the build.

No generated bytes change.

## Verification

- `go test ./...` passes, `golangci-lint run ./...` reports 0 issues.
- `go test -fuzz FuzzFrontMatterTitle -fuzztime 45s .` — 1.2M executions, no failures, with the skip removed.