### PR TITLE
fix(mermaid): escape the quote that loses a flowchart

### DIFF
--- a/doc/edgecase/flowchart.md
+++ b/doc/edgecase/flowchart.md
@@ -4,12 +4,12 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 ---
-title: "title '#;[](){}🎉日本語:,*-|%%"
+title: "title \"'#;[](){}🎉日本語:,*-|%%\\"
 ---
 flowchart TB
-    A["before '#;[](){}🎉日本語:,*-|%% after"]
-    B{"x'#;[](){}🎉日本語:,*-|%%x"}
-    C(("x'#;[](){}🎉日本語:,*-|%%x"))
-    A-->|"x'#;[](){}🎉日本語:,*-|%%x"|B
-    B-. "x'#;[](){}🎉日本語:,*-|%%x" .-> C
+    A["before #quot;'#;[](){}🎉日本語:,*-|%%\ after"]
+    B{"x#quot;'#;[](){}🎉日本語:,*-|%%\x"}
+    C(("x#quot;'#;[](){}🎉日本語:,*-|%%\x"))
+    A-->|"x#quot;'#;[](){}🎉日本語:,*-|%%\x"|B
+    B-. "x#quot;'#;[](){}🎉日本語:,*-|%%\x" .-> C
 ```

--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -80,8 +80,11 @@ func supported(diagram string) string {
 		"class": `"'#[](){}` + emoji + japanese + `,*-|%%`,
 		// er: a double quote ends the comment it is written in.
 		"er": `'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
-		// flowchart: a double quote ends the node text it is written in.
-		"flowchart": `'#;[](){}` + emoji + japanese + `:,*-|%%`,
+		// flowchart quotes every label and writes a double quote as the entity
+		// form mermaid decodes, so the punctuation is all safe. What is left
+		// out is a line break: the renderer honours "<br/>" inside a label,
+		// which is what a caller wanting one should pass.
+		"flowchart": `"'#;[](){}` + emoji + japanese + `:,*-|%%\`,
 		// gantt: a colon separates a task name from its data.
 		"gantt":    `"'#;[](){}<br/>` + emoji + japanese + `,*-|%%`,
 		"gitgraph": `"'#;[](){}` + emoji + japanese + `:,*-|%%`,

--- a/mermaid/flowchart/escape.go
+++ b/mermaid/flowchart/escape.go
@@ -1,0 +1,59 @@
+package flowchart
+
+import "strings"
+
+// escapeText returns text ready to be written inside a flowchart's quoted
+// label.
+//
+// A double quote ends the label, and mermaid refuses the whole diagram when one
+// appears inside it: the reader gets an error box instead of a picture. Neither
+// escape that looks obvious works. A backslash is not an escape to mermaid's
+// flowchart lexer and fails the same way, and doubling the quote fails too.
+// What mermaid does implement is its own entity form, "#quot;", which was found
+// by rendering all four.
+//
+// A "#" that starts one of those entities is escaped for the same reason, and
+// only then: mermaid reads "#quot;" and "#123;" as the characters they name, so
+// without this a label holding "#quot;" and a label holding a quotation mark
+// would produce the same diagram. A "#" anywhere else is ordinary text and is
+// left exactly as it was, because that output already renders and is pinned by
+// the golden files.
+func escapeText(text string) string {
+	if !strings.ContainsAny(text, `"#`) {
+		return text
+	}
+
+	var b strings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		switch {
+		case text[i] == '"':
+			b.WriteString("#quot;")
+		case text[i] == '#' && startsEntity(text[i+1:]):
+			b.WriteString("#35;")
+		default:
+			b.WriteByte(text[i])
+		}
+	}
+	return b.String()
+}
+
+// startsEntity reports whether rest completes an entity that began with a "#",
+// that is whether it opens with one or more letters or digits and then a ";".
+func startsEntity(rest string) bool {
+	for i := 0; i < len(rest); i++ {
+		switch {
+		case rest[i] == ';':
+			return i > 0
+		case isEntityByte(rest[i]):
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// isEntityByte reports whether c may appear in an entity name.
+func isEntityByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}

--- a/mermaid/flowchart/flowchart_test.go
+++ b/mermaid/flowchart/flowchart_test.go
@@ -402,3 +402,79 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestNodeTextEscapesTheQuoteThatEndsIt names the character this escaping
+// buys. A double quote in a node label used to reach mermaid unescaped and lose
+// the whole diagram: the reader got an error box rather than a picture.
+func TestNodeTextEscapesTheQuoteThatEndsIt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(*Flowchart) *Flowchart
+		want  string
+	}{
+		"a quote in node text": {
+			build: func(f *Flowchart) *Flowchart { return f.NodeWithText("A", `say "hi"`) },
+			want:  `    A["say #quot;hi#quot;"]`,
+		},
+		"a quote in a markdown node": {
+			build: func(f *Flowchart) *Flowchart { return f.NodeWithMarkdown("A", `say "hi"`) },
+			want:  "    A[\"`say #quot;hi#quot;`\"]",
+		},
+		"a quote in every other node shape": {
+			build: func(f *Flowchart) *Flowchart { return f.HexagonNode("A", `"`) },
+			want:  `    A{{"#quot;"}}`,
+		},
+		"a quote in link text": {
+			build: func(f *Flowchart) *Flowchart { return f.LinkWithArrowHeadAndText("A", "B", `"`) },
+			want:  `    A-->|"#quot;"|B`,
+		},
+		"a quote in dotted link text": {
+			build: func(f *Flowchart) *Flowchart { return f.DottedLinkWithText("A", "B", `"`) },
+			want:  `    A-. "#quot;" .-> B`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(NewFlowchart(io.Discard)).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNodeTextEscapesOnlyTheHashThatStartsAnEntity pins the other half of the
+// escaping. mermaid reads "#quot;" and "#123;" as the characters they name, so
+// a label holding one has to be escaped or it would draw the same diagram as a
+// label holding a quotation mark. A "#" anywhere else is ordinary text, and its
+// output is left exactly as it was.
+func TestNodeTextEscapesOnlyTheHashThatStartsAnEntity(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		text string
+		want string
+	}{
+		"a plain hash is left alone":            {text: "PR #123 merged", want: `    A["PR #123 merged"]`},
+		"a hash at the end is left alone":       {text: "issue #", want: `    A["issue #"]`},
+		"a hash before a semicolon is left too": {text: "a#;b", want: `    A["a#;b"]`},
+		"a named entity is escaped":             {text: "a#quot;b", want: `    A["a#35;quot;b"]`},
+		"a numeric entity is escaped":           {text: "a#123;b", want: `    A["a#35;123;b"]`},
+		"a quote and an entity together":        {text: `#39;"`, want: `    A["#35;39;#quot;"]`},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := NewFlowchart(io.Discard).NodeWithText("A", tt.text).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}

--- a/mermaid/flowchart/link.go
+++ b/mermaid/flowchart/link.go
@@ -10,7 +10,7 @@ func (f *Flowchart) LinkWithArrowHead(from, to string) *Flowchart {
 
 // LinkWithArrowHeadAndText adds a link with an arrow head and text to the flowchart.
 func (f *Flowchart) LinkWithArrowHeadAndText(from, to, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s-->|\"%s\"|%s", from, text, to))
+	f.body = append(f.body, fmt.Sprintf("    %s-->|\"%s\"|%s", from, escapeText(text), to))
 	return f
 }
 
@@ -22,7 +22,7 @@ func (f *Flowchart) OpenLink(from, to string) *Flowchart {
 
 // OpenLinkWithText adds an open link with text to the flowchart.
 func (f *Flowchart) OpenLinkWithText(from, to, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s---|\"%s\"|%s", from, text, to))
+	f.body = append(f.body, fmt.Sprintf("    %s---|\"%s\"|%s", from, escapeText(text), to))
 	return f
 }
 
@@ -34,7 +34,7 @@ func (f *Flowchart) DottedLink(from, to string) *Flowchart {
 
 // DottedLinkWithText adds a dotted link with text to the flowchart.
 func (f *Flowchart) DottedLinkWithText(from, to, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s-. \"%s\" .-> %s", from, text, to))
+	f.body = append(f.body, fmt.Sprintf("    %s-. \"%s\" .-> %s", from, escapeText(text), to))
 	return f
 }
 
@@ -46,7 +46,7 @@ func (f *Flowchart) ThickLink(from, to string) *Flowchart {
 
 // ThickLinkWithText adds a thick link with text to the flowchart.
 func (f *Flowchart) ThickLinkWithText(from, to, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s == \"%s\" ==> %s", from, text, to))
+	f.body = append(f.body, fmt.Sprintf("    %s == \"%s\" ==> %s", from, escapeText(text), to))
 	return f
 }
 

--- a/mermaid/flowchart/node.go
+++ b/mermaid/flowchart/node.go
@@ -11,43 +11,43 @@ func (f *Flowchart) Node(name string) *Flowchart {
 // NodeWithText adds a node with text to the flowchart.
 // Unicode characters are supported.
 func (f *Flowchart) NodeWithText(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\"%s\"]", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s[\"%s\"]", name, escapeText(text)))
 	return f
 }
 
 // NodeWithMarkdown adds a node with markdown text to the flowchart.
 func (f *Flowchart) NodeWithMarkdown(name, markdownText string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\"`%s`\"]", name, markdownText))
+	f.body = append(f.body, fmt.Sprintf("    %s[\"`%s`\"]", name, escapeText(markdownText)))
 	return f
 }
 
 // NodeWithNewLines adds a node with new lines to the flowchart.
 func (f *Flowchart) NodeWithNewLines(name, textWithNewLines string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\"`%s`\"]", name, textWithNewLines))
+	f.body = append(f.body, fmt.Sprintf("    %s[\"`%s`\"]", name, escapeText(textWithNewLines)))
 	return f
 }
 
 // RoundEdgesNode adds a node with round edges to the flowchart.
 func (f *Flowchart) RoundEdgesNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s(\"%s\")", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s(\"%s\")", name, escapeText(text)))
 	return f
 }
 
 // StadiumNode adds a node with stadium shape to the flowchart.
 func (f *Flowchart) StadiumNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s([\"%s\"])", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s([\"%s\"])", name, escapeText(text)))
 	return f
 }
 
 // SubroutineNode adds a node with subroutine shape to the flowchart.
 func (f *Flowchart) SubroutineNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[[\"%s\"]]", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s[[\"%s\"]]", name, escapeText(text)))
 	return f
 }
 
 // CylindricalNode adds a node with cylindrical shape to the flowchart.
 func (f *Flowchart) CylindricalNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[(\"%s\")]", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s[(\"%s\")]", name, escapeText(text)))
 	return f
 }
 
@@ -59,54 +59,54 @@ func (f *Flowchart) DatabaseNode(name, text string) *Flowchart {
 
 // CircleNode adds a node with circle shape to the flowchart.
 func (f *Flowchart) CircleNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s((\"%s\"))", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s((\"%s\"))", name, escapeText(text)))
 	return f
 }
 
 // AsymmetricNode adds a node with asymmetric shape to the flowchart.
 func (f *Flowchart) AsymmetricNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s>\"%s\"]", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s>\"%s\"]", name, escapeText(text)))
 	return f
 }
 
 // RhombusNode adds a node with rhombus shape to the flowchart.
 func (f *Flowchart) RhombusNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s{\"%s\"}", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s{\"%s\"}", name, escapeText(text)))
 	return f
 }
 
 // HexagonNode adds a node with hexagon shape to the flowchart.
 func (f *Flowchart) HexagonNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s{{\"%s\"}}", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s{{\"%s\"}}", name, escapeText(text)))
 	return f
 }
 
 // ParallelogramNode adds a node with parallelogram shape to the flowchart.
 func (f *Flowchart) ParallelogramNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[/\"%s\"/]", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s[/\"%s\"/]", name, escapeText(text)))
 	return f
 }
 
 // ParallelogramAltNode adds a node with parallelogram shape to the flowchart.
 func (f *Flowchart) ParallelogramAltNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\\\"%s\"\\]", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s[\\\"%s\"\\]", name, escapeText(text)))
 	return f
 }
 
 // TrapezoidNode adds a node with trapezoid shape to the flowchart.
 func (f *Flowchart) TrapezoidNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[/\"%s\"\\]", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s[/\"%s\"\\]", name, escapeText(text)))
 	return f
 }
 
 // TrapezoidAltNode adds a node with trapezoid shape to the flowchart.
 func (f *Flowchart) TrapezoidAltNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\\\"%s\"/]", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s[\\\"%s\"/]", name, escapeText(text)))
 	return f
 }
 
 // DoubleCircleNode adds a node with double circle shape to the flowchart.
 func (f *Flowchart) DoubleCircleNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s(((\"%s\")))", name, text))
+	f.body = append(f.body, fmt.Sprintf("    %s(((\"%s\")))", name, escapeText(text)))
 	return f
 }


### PR DESCRIPTION
Refs #146 — one subpackage per pull request, as the issue asks. This is `flowchart`.

## The defect

A `"` in a node label or a link label ended the string it was written in, and mermaid refused the whole diagram. The failure is total: the reader gets an error box instead of a picture. A quotation mark is exactly what arrives in a label from a database row or a command's output.

## The escape, measured

I rendered all four candidates:

| form | result |
|---|---|
| `"` (today) | mermaid refuses the diagram |
| `\"` | refuses it the same way — a backslash is not an escape to this lexer |
| `""` | refuses it too |
| `#quot;` | draws a `"` |

So `"` is written as `#quot;`, in every node shape and every link label.

## Why `#` is touched too

`#quot;` only works because mermaid reads `#name;` and `#123;` as the characters they name. That makes a caller's literal `#quot;` collide with a caller's literal `"` unless it is escaped, so a `#` **that starts an entity** is written `#35;`.

A `#` anywhere else is left exactly as it was — `PR #123 merged`, `issue #`, `a#;b` all come out byte for byte identical. That is deliberate: the issue's hard constraint is not to change output that already renders, and no golden file or documentation sample moves in this PR.

## Verification

- `go test ./...` passes with **no golden file changed**, which is the check that existing output is untouched.
- `golangci-lint run ./...` reports 0 issues.
- `mermaid/flowchart` coverage is 99.0%; two new tests name the characters bought and pin the `#` rule on both sides.
- The `flowchart` entry in `doc/edgecase/main.go` widens to the full probe set (`"'#;[](){}` + emoji + Japanese + `:,*-|%%\`) and the document is regenerated. Every committed diagram renders: **61 blocks, 0 failed**.

`<br/>` stays out of that entry on purpose: the renderer honours it as a line break, which is what a caller wanting one should pass, so it is not a character the label can carry.