### PR TITLE
fix(mermaid): escape the quote and the comment that break a pie chart

### DIFF
--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -96,8 +96,11 @@ func supported(diagram string) string {
 		// packet and piechart put the title in YAML front matter, and mermaid
 		// strips a "%%" comment from that before the YAML is read.
 		"packet": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|`,
-		// piechart: a double quote ends the quoted label.
-		"piechart": `'#;[](){}<br/>` + emoji + japanese + `:,*-|`,
+		// piechart quotes a slice label and writes a double quote as the entity
+		// form mermaid decodes. Its title is unquoted, so a "%%" there would
+		// open a comment and cut the title short; that pair is written as an
+		// entity too.
+		"piechart": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
 		// radar quotes every label, so the punctuation is all safe. A line
 		// break is the only thing left out, since one label is one line.
 		"radar": `"'#;[](){}` + emoji + japanese + `:,*-|%%`,

--- a/doc/edgecase/piechart.md
+++ b/doc/edgecase/piechart.md
@@ -5,7 +5,7 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 ```mermaid
 %%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
 pie showData
-    title title '#;[](){}🎉日本語:,*-|
-    "x'#;[](){}<br/>🎉日本語:,*-|x" : 120
-    "x'#;[](){}<br/>🎉日本語:,*-|x two" : 42.500000
+    title title "'#;[](){}🎉日本語:,*-|#37;#37;
+    "x#quot;'#;[](){}<br/>🎉日本語:,*-|%%x" : 120
+    "x#quot;'#;[](){}<br/>🎉日本語:,*-|%%x two" : 42.500000
 ```

--- a/internal/entity.go
+++ b/internal/entity.go
@@ -1,0 +1,54 @@
+package internal
+
+import "strconv"
+
+// Mermaid reads "#name;" and "#123;" inside the text of a diagram as the
+// character that name or number stands for. It is the only escape several of
+// its grammars have: a construct that takes a quoted label has no way to spell
+// a quotation mark otherwise, and a construct that reads the rest of the line
+// has no way to spell the punctuation that ends it.
+//
+// The two helpers here are the fiddly halves of using that escape, shared
+// because the diagram types that need it each need both. Which characters a
+// given type has to escape, and when, is the type's own business and stays in
+// its package: the answers differ, and every one of them was measured by
+// rendering rather than guessed.
+
+// EntityEscape returns the mermaid escape for r, for example "#quot;" for a
+// double quote.
+//
+// The numeric form is used for everything except the double quote, which is
+// written by name because that is the form mermaid's own documentation shows
+// and the form a reader of the generated diagram will recognise.
+func EntityEscape(r rune) string {
+	if r == '"' {
+		return "#quot;"
+	}
+	return "#" + strconv.Itoa(int(r)) + ";"
+}
+
+// StartsEntity reports whether s opens with the rest of a "#name;" or "#123;"
+// escape, that is whether a "#" written immediately before it would be read as
+// one rather than as an ordinary character.
+//
+// This is what keeps the escaping injective. A package that writes a quotation
+// mark as "#quot;" has to escape a caller's literal "#quot;" as well, or the
+// two would produce the same diagram. A "#" anywhere else is ordinary text and
+// is left alone, which is what keeps output that already renders unchanged.
+func StartsEntity(s string) bool {
+	for i := 0; i < len(s); i++ {
+		switch {
+		case s[i] == ';':
+			return i > 0
+		case isEntityByte(s[i]):
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// isEntityByte reports whether c may appear between the "#" and the ";".
+func isEntityByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}

--- a/internal/entity.go
+++ b/internal/entity.go
@@ -19,7 +19,7 @@ import "strconv"
 //
 // The numeric form is used for everything except the double quote, which is
 // written by name because that is the form mermaid's own documentation shows
-// and the form a reader of the generated diagram will recognise.
+// and the form a reader of the generated diagram will recognize.
 func EntityEscape(r rune) string {
 	if r == '"' {
 		return "#quot;"

--- a/internal/entity_test.go
+++ b/internal/entity_test.go
@@ -1,0 +1,63 @@
+package internal
+
+import "testing"
+
+func TestEntityEscape(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		r    rune
+		want string
+	}{
+		"a double quote is written by name": {r: '"', want: "#quot;"},
+		"a hash is written by number":       {r: '#', want: "#35;"},
+		"a percent is written by number":    {r: '%', want: "#37;"},
+		"a semicolon is written by number":  {r: ';', want: "#59;"},
+		"a colon is written by number":      {r: ':', want: "#58;"},
+		"an emoji keeps its code point":     {r: '🎉', want: "#127881;"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := EntityEscape(tt.r); got != tt.want {
+				t.Errorf("EntityEscape(%q) = %q, want %q", tt.r, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStartsEntity pins where the line falls between a "#" that has to be
+// escaped and one that is ordinary text. Getting this wrong in either direction
+// is a defect: too eager and output that already renders changes, too shy and a
+// caller's literal "#quot;" draws a quotation mark.
+func TestStartsEntity(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		rest string
+		want bool
+	}{
+		"a name and a semicolon":            {rest: "quot;", want: true},
+		"digits and a semicolon":            {rest: "123;", want: true},
+		"a name followed by more text":      {rest: "quot;b", want: true},
+		"one letter is enough":              {rest: "a;", want: true},
+		"nothing at all":                    {rest: "", want: false},
+		"a semicolon on its own":            {rest: ";", want: false},
+		"a name that never closes":          {rest: "quot", want: false},
+		"a space before the semicolon":      {rest: "a b;", want: false},
+		"punctuation before the semicolon":  {rest: "a-b;", want: false},
+		"another hash before the semicolon": {rest: "a#b;", want: false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := StartsEntity(tt.rest); got != tt.want {
+				t.Errorf("StartsEntity(%q) = %v, want %v", tt.rest, got, tt.want)
+			}
+		})
+	}
+}

--- a/mermaid/flowchart/escape.go
+++ b/mermaid/flowchart/escape.go
@@ -1,6 +1,10 @@
 package flowchart
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
 
 // escapeText returns text ready to be written inside a flowchart's quoted
 // label.
@@ -28,32 +32,12 @@ func escapeText(text string) string {
 	for i := 0; i < len(text); i++ {
 		switch {
 		case text[i] == '"':
-			b.WriteString("#quot;")
-		case text[i] == '#' && startsEntity(text[i+1:]):
-			b.WriteString("#35;")
+			b.WriteString(internal.EntityEscape('"'))
+		case text[i] == '#' && internal.StartsEntity(text[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
 		default:
 			b.WriteByte(text[i])
 		}
 	}
 	return b.String()
-}
-
-// startsEntity reports whether rest completes an entity that began with a "#",
-// that is whether it opens with one or more letters or digits and then a ";".
-func startsEntity(rest string) bool {
-	for i := 0; i < len(rest); i++ {
-		switch {
-		case rest[i] == ';':
-			return i > 0
-		case isEntityByte(rest[i]):
-		default:
-			return false
-		}
-	}
-	return false
-}
-
-// isEntityByte reports whether c may appear in an entity name.
-func isEntityByte(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }

--- a/mermaid/piechart/escape.go
+++ b/mermaid/piechart/escape.go
@@ -1,0 +1,76 @@
+package piechart
+
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+// escapeLabel returns label ready to be written inside a pie chart's quoted
+// slice label.
+//
+// A double quote ends the label, and mermaid then refuses the whole chart: the
+// reader gets an error box instead of a picture. It is written as mermaid's own
+// entity form instead. A backslash happens to work here too, unlike in a
+// flowchart, but the entity form is what every other builder in this library
+// writes and what mermaid documents.
+//
+// A "#" that would start an entity is escaped for the reason the escape exists
+// at all: mermaid reads "#quot;" as a quotation mark, so a label holding one
+// has to be spelled differently from a label holding the mark itself. A "#"
+// anywhere else is ordinary text and comes out unchanged.
+func escapeLabel(label string) string {
+	if !strings.ContainsAny(label, `"#`) {
+		return label
+	}
+
+	var b strings.Builder
+	b.Grow(len(label))
+	for i := 0; i < len(label); i++ {
+		switch {
+		case label[i] == '"':
+			b.WriteString(internal.EntityEscape('"'))
+		case label[i] == '#' && internal.StartsEntity(label[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(label[i])
+		}
+	}
+	return b.String()
+}
+
+// escapeTitle returns title ready to be written after the "title" keyword.
+//
+// The title is the one place a pie chart takes unquoted text, so a quotation
+// mark needs nothing here. What it cannot take is "%%", which starts a mermaid
+// comment: everything from there to the end of the line is dropped, and the
+// title is silently cut short rather than the chart failing. Each "%" in such a
+// run is written as its entity so the pair never forms.
+//
+// A lone "%" is left alone, and so is a "#" that starts nothing. Both already
+// reach the drawing intact, and their output is pinned by the golden files.
+func escapeTitle(title string) string {
+	if !strings.ContainsAny(title, "%#") {
+		return title
+	}
+
+	var b strings.Builder
+	b.Grow(len(title))
+	for i := 0; i < len(title); i++ {
+		switch {
+		case title[i] == '%' && adjacentPercent(title, i):
+			b.WriteString(internal.EntityEscape('%'))
+		case title[i] == '#' && internal.StartsEntity(title[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(title[i])
+		}
+	}
+	return b.String()
+}
+
+// adjacentPercent reports whether the "%" at index i has another beside it, and
+// so is part of the run that would open a comment.
+func adjacentPercent(title string, i int) bool {
+	return (i > 0 && title[i-1] == '%') || (i+1 < len(title) && title[i+1] == '%')
+}

--- a/mermaid/piechart/pie_chart.go
+++ b/mermaid/piechart/pie_chart.go
@@ -52,7 +52,7 @@ func NewPieChart(w io.Writer, opts ...Option) *PieChart {
 		lines = append(lines, baseLine)
 	} else {
 		lines = append(lines, baseLine)
-		lines = append(lines, fmt.Sprintf("    title %s", c.title))
+		lines = append(lines, fmt.Sprintf("    title %s", escapeTitle(c.title)))
 	}
 
 	return &PieChart{
@@ -87,13 +87,13 @@ func (p *PieChart) Build() error {
 
 // LabelAndIntValue adds a label and value to the pie chart.
 func (p *PieChart) LabelAndIntValue(label string, value uint64) *PieChart {
-	p.body = append(p.body, fmt.Sprintf("    \"%s\" : %d", label, value))
+	p.body = append(p.body, fmt.Sprintf("    \"%s\" : %d", escapeLabel(label), value))
 	return p
 }
 
 // LabelAndFloatValue adds a label and value to the pie chart.
 // The value is formatted with a precision of 6 digits after the decimal point.
 func (p *PieChart) LabelAndFloatValue(label string, value float64) *PieChart {
-	p.body = append(p.body, fmt.Sprintf("    \"%s\" : %f", label, value))
+	p.body = append(p.body, fmt.Sprintf("    \"%s\" : %f", escapeLabel(label), value))
 	return p
 }

--- a/mermaid/piechart/pie_chart_test.go
+++ b/mermaid/piechart/pie_chart_test.go
@@ -224,3 +224,83 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestLabelEscapesTheQuoteThatEndsIt names the character this escaping buys. A
+// double quote in a slice label used to reach mermaid unescaped and lose the
+// whole chart: the reader got an error box rather than a picture.
+func TestLabelEscapesTheQuoteThatEndsIt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(*PieChart) *PieChart
+		want  string
+	}{
+		"a quote in an int label": {
+			build: func(p *PieChart) *PieChart {
+				return p.LabelAndIntValue(`say "hi"`, 10)
+			},
+			want: `    "say #quot;hi#quot;" : 10`,
+		},
+		"a quote in a float label": {
+			build: func(p *PieChart) *PieChart {
+				return p.LabelAndFloatValue(`"`, 1.5)
+			},
+			want: `    "#quot;" : 1.500000`,
+		},
+		"a named entity in a label is escaped": {
+			build: func(p *PieChart) *PieChart {
+				return p.LabelAndIntValue("a#quot;b", 10)
+			},
+			want: `    "a#35;quot;b" : 10`,
+		},
+		"a plain hash in a label is left alone": {
+			build: func(p *PieChart) *PieChart {
+				return p.LabelAndIntValue("PR #123 merged", 10)
+			},
+			want: `    "PR #123 merged" : 10`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(NewPieChart(io.Discard)).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("chart =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTitleEscapesThePercentPairThatCommentsItOut names the other character
+// this buys. The title is unquoted, so a "%%" in one opened a mermaid comment
+// and the rest of the title was dropped from the drawing without any error.
+func TestTitleEscapesThePercentPairThatCommentsItOut(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		title string
+		want  string
+	}{
+		"a percent pair is escaped":          {title: "100%% done", want: "    title 100#37;#37; done"},
+		"a longer run is escaped whole":      {title: "a%%%b", want: "    title a#37;#37;#37;b"},
+		"a lone percent is left alone":       {title: "100% done", want: "    title 100% done"},
+		"percents apart are left alone":      {title: "50% of 10%", want: "    title 50% of 10%"},
+		"a named entity is escaped":          {title: "a#quot;b", want: "    title a#35;quot;b"},
+		"a plain hash is left alone":         {title: "PR #123 merged", want: "    title PR #123 merged"},
+		"a quote needs nothing when bare":    {title: `the "core"`, want: `    title the "core"`},
+		"text with neither is left as it is": {title: "Sales", want: "    title Sales"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := NewPieChart(io.Discard, WithTitle(tt.title)).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("chart =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `piechart`.

## The defects

Two, and the second is not in the issue's table because the render harness only measures characters that *lose* the diagram:

1. A `"` in a slice label ends the label. mermaid refuses the whole chart — error box, no picture.
2. A `%%` in the title opens a mermaid comment. The rest of the title is dropped and **the chart still draws**, saying something other than what was asked for. Silent, and worse.

## The escapes, measured

For the label, rendering all four candidates:

| form | result |
|---|---|
| `"` (today) | lexer error, chart lost |
| `&quot;` | draws the literal text `&quot;` |
| `\"` | draws a `"` — works here, unlike in a flowchart |
| `#quot;` | draws a `"` |

`#quot;` wins on consistency: it is what `flowchart`, `c4` and mermaid's own documentation use.

For the title, `#37;#37;` draws `%%`, so each `%` of a run is written as its entity and the pair never forms.

## Both escapes are deliberately narrow

- Only a `%` with another `%` beside it is escaped. `100% done` and `50% of 10%` come out byte for byte as before.
- Only a `#` that would start an entity is escaped. `PR #123 merged` does too.

No golden file and no documentation sample moves — that is the issue's hard constraint, and `go test ./...` passing unchanged is the check for it.

## internal/entity.go

`EntityEscape` and `StartsEntity` moved to `internal`. The flowchart fix (#157) already needed both and this one needs them again, with ten more diagram types to go. What is *not* shared is which characters a given type escapes and when — those differ per grammar, each was measured by rendering, and each stays in its own package with the measurement written down.

`internal` is back to 100% statement coverage, with a test that pins exactly where the line falls between a `#` that must be escaped and one that is ordinary text.

## Verification

- `go test ./...` passes with no golden file changed; `golangci-lint run ./...` reports 0 issues.
- `mermaid/piechart` coverage 98.2%, `internal` 100%.
- The `piechart` entry in `doc/edgecase/main.go` widens to `"'#;[](){}<br/>` + emoji + Japanese + `:,*-|%%` and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pie chart rendering for labels and titles containing quotes, percent signs, hashes, Unicode, and Mermaid entities.
  - Prevented special characters from being misinterpreted as Mermaid comments or markup.
  - Preserved existing numeric formatting and ordinary punctuation.
- **Tests**
  - Added regression coverage for special-character escaping in pie charts and flowcharts.
- **Documentation**
  - Updated edge-case examples to demonstrate the corrected escaping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->