### PR TITLE
fix(mermaid): escape the quote that loses an entity relationship diagram

### DIFF
--- a/doc/edgecase/er.md
+++ b/doc/edgecase/er.md
@@ -4,12 +4,12 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 erDiagram
-    teachers ||--o{ students : "before '#;[](){}<br/>🎉日本語:,*-|%% after"
+    teachers ||--o{ students : "before #quot;'#;[](){}<br/>🎉日本語:,*-|%% after"
     students {
-        int teacher_id FK "before '#;[](){}<br/>🎉日本語:,*-|%% after"
+        int teacher_id FK "before #quot;'#;[](){}<br/>🎉日本語:,*-|%% after"
     }
     teachers {
-        int id PK "before '#;[](){}<br/>🎉日本語:,*-|%% after"
+        int id PK "before #quot;'#;[](){}<br/>🎉日本語:,*-|%% after"
     }
 
 ```

--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -78,8 +78,9 @@ func supported(diagram string) string {
 		"c4": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%\`,
 		// class: ";" and ":" end a relation label.
 		"class": `"'#[](){}` + emoji + japanese + `,*-|%%`,
-		// er: a double quote ends the comment it is written in.
-		"er": `'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
+		// er writes a comment as the entity form mermaid decodes, so the
+		// punctuation is all safe.
+		"er": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
 		// flowchart quotes every label and writes a double quote as the entity
 		// form mermaid decodes, so the punctuation is all safe. What is left
 		// out is a line break: the renderer honours "<br/>" inside a label,

--- a/mermaid/er/entity.go
+++ b/mermaid/er/entity.go
@@ -70,7 +70,7 @@ func (a *Attribute) string() string {
 		keys = append(keys, "UK")
 	}
 
-	s := fmt.Sprintf("        %s %s %s \"%s\"", a.Type, a.Name, strings.Join(keys, ","), a.Comment)
+	s := fmt.Sprintf("        %s %s %s \"%s\"", a.Type, a.Name, strings.Join(keys, ","), escapeComment(a.Comment))
 	s = strings.TrimSuffix(s, " ")
 	return strings.ReplaceAll(s, "\"\"", "")
 }
@@ -90,7 +90,7 @@ func (d *Diagram) Relationship(leftE, rightE Entity, leftR, rightR Relationship,
 			identidy.string(),
 			rightR.string(right),
 			rightE.Name,
-			comment,
+			escapeComment(comment),
 		),
 	)
 

--- a/mermaid/er/entity_relationship_test.go
+++ b/mermaid/er/entity_relationship_test.go
@@ -345,3 +345,62 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestCommentEscapesTheQuoteThatEndsIt names the character this escaping buys.
+// A double quote in an attribute comment or a relationship comment used to
+// reach mermaid unescaped and lose the whole diagram: the reader got an error
+// box rather than a picture.
+func TestCommentEscapesTheQuoteThatEndsIt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(io.Writer) *Diagram
+		want  string
+	}{
+		"a quote in an attribute comment": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).NoRelationship(NewEntity("teachers", []*Attribute{
+					{Type: "int", Name: "id", IsPrimaryKey: true, Comment: `the "primary" key`},
+				}))
+			},
+			want: `        int id PK "the #quot;primary#quot; key"`,
+		},
+		"a quote in a relationship comment": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Relationship(
+					NewEntity("teachers", []*Attribute{{Type: "int", Name: "id"}}),
+					NewEntity("students", []*Attribute{{Type: "int", Name: "id"}}),
+					ExactlyOneRelationship, ZeroToMoreRelationship, Identifying, `"teaches"`,
+				)
+			},
+			want: `"#quot;teaches#quot;"`,
+		},
+		"a named entity in a comment is escaped": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).NoRelationship(NewEntity("teachers", []*Attribute{
+					{Type: "int", Name: "id", Comment: "a#quot;b"},
+				}))
+			},
+			want: `"a#35;quot;b"`,
+		},
+		"a plain hash in a comment is left alone": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).NoRelationship(NewEntity("teachers", []*Attribute{
+					{Type: "int", Name: "id", Comment: "PR #123 merged"},
+				}))
+			},
+			want: `"PR #123 merged"`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(io.Discard).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}

--- a/mermaid/er/escape.go
+++ b/mermaid/er/escape.go
@@ -1,0 +1,44 @@
+package er
+
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+// escapeComment returns comment ready to be written inside the quoted string an
+// entity relationship diagram puts a comment in.
+//
+// A double quote ends that string, and mermaid then refuses the whole diagram:
+// the reader gets an error box instead of a picture. A comment is prose, which
+// is exactly where a quotation mark comes from, and escaping it is the
+// builder's job rather than the caller's.
+//
+// A backslash is not an escape to mermaid's entity relationship lexer and fails
+// the same way the bare quote does. What mermaid implements is its own entity
+// form, "#quot;", which was found by rendering both.
+//
+// A "#" that would start an entity is escaped for the same reason, and only
+// then: mermaid reads "#quot;" and "#123;" as the characters they name, so
+// without this a comment holding "#quot;" and a comment holding a quotation
+// mark would produce the same diagram. A "#" anywhere else is ordinary text and
+// comes out unchanged, which is what keeps the golden files as they are.
+func escapeComment(comment string) string {
+	if !strings.ContainsAny(comment, `"#`) {
+		return comment
+	}
+
+	var b strings.Builder
+	b.Grow(len(comment))
+	for i := 0; i < len(comment); i++ {
+		switch {
+		case comment[i] == '"':
+			b.WriteString(internal.EntityEscape('"'))
+		case comment[i] == '#' && internal.StartsEntity(comment[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(comment[i])
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `er`.

> **Stacked on #159**, which adds `internal/entity.go`. The base is set to that branch; it retargets to `main` automatically when #159 merges. Review the last commit only.

## The defect

A `"` in an attribute comment or a relationship comment ended the quoted string it was written in, and mermaid refused the whole diagram. A comment is prose — a quotation mark is exactly what turns up in one.

## The escape, measured

| form | result |
|---|---|
| `"` (today) | parse error, diagram lost |
| `\"` | parse error too — not an escape to this lexer |
| `&quot;` | draws a `"`, but is not mermaid's own form |
| `#quot;` | draws a `"` |

`#quot;` it is, matching `flowchart`, `piechart` and `c4`.

A `#` that would start an entity is escaped along with it, so a comment holding `#quot;` stays distinguishable from one holding a quotation mark. A `#` anywhere else — `PR #123 merged` — comes out byte for byte as before, and no golden file moves.

## Verification

- `go test ./...` passes with no golden file changed; `golangci-lint run ./...` reports 0 issues.
- `mermaid/er` coverage 95.9%.
- The `er` entry in `doc/edgecase/main.go` widens to the full probe set and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.