### PR TITLE
fix(mermaid): escape the colon that cuts a gantt task name short

### DIFF
--- a/doc/edgecase/gantt.md
+++ b/doc/edgecase/gantt.md
@@ -4,9 +4,9 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 gantt
-    title title "'#;[](){}🎉日本語,*-|%%
+    title title "'#;[](){}🎉日本語:,*-|%%
     dateFormat YYYY-MM-DD
-    section x"'#;[](){}<br/>🎉日本語,*-|%%x
-    x"'#;[](){}<br/>🎉日本語,*-|%%x :2024-01-01, 2d
-    x"'#;[](){}<br/>🎉日本語,*-|%%x :milestone, milestone, 2024-01-03, 0d
+    section x"'#;[](){}<br/>🎉日本語:,*-|%%x
+    x"'#;[](){}<br/>🎉日本語#58;,*-|%%x :2024-01-01, 2d
+    x"'#;[](){}<br/>🎉日本語#58;,*-|%%x :milestone, milestone, 2024-01-03, 0d
 ```

--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -85,8 +85,9 @@ func supported(diagram string) string {
 		// out is a line break: the renderer honours "<br/>" inside a label,
 		// which is what a caller wanting one should pass.
 		"flowchart": `"'#;[](){}` + emoji + japanese + `:,*-|%%\`,
-		// gantt: a colon separates a task name from its data.
-		"gantt":    `"'#;[](){}<br/>` + emoji + japanese + `,*-|%%`,
+		// gantt writes the colon that separates a task name from its data as
+		// the entity form mermaid decodes, so the punctuation is all safe.
+		"gantt":    `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
 		"gitgraph": `"'#;[](){}` + emoji + japanese + `:,*-|%%`,
 		// kanban: quotes end the single quoted metadata, and square brackets
 		// and a closing brace end a node.

--- a/mermaid/gantt/escape.go
+++ b/mermaid/gantt/escape.go
@@ -1,0 +1,44 @@
+package gantt
+
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+// escapeTaskName returns name ready to be written before the colon that starts
+// a task's data.
+//
+// A gantt task is written "name :data", and mermaid splits the line at the
+// first colon. A colon inside the name therefore ends it early and everything
+// after becomes task data: the chart still draws, with a task named "Deploy"
+// where the caller asked for "Deploy: staging". That is the quiet kind of
+// failure, worse than a diagram that is lost, because nothing reports it.
+//
+// mermaid reads its own entity form in a task name, so a colon is written
+// "#58;" and reaches the drawing as a colon. A "#" that would start an entity
+// is escaped with it, or a name holding "#58;" and a name holding a colon would
+// draw the same task. A "#" anywhere else is ordinary text and comes out
+// unchanged, which is what keeps the golden files as they are.
+//
+// The section name and the title need none of this: mermaid reads each as the
+// rest of its line, and a colon in one already reaches the drawing intact.
+func escapeTaskName(name string) string {
+	if !strings.ContainsAny(name, ":#") {
+		return name
+	}
+
+	var b strings.Builder
+	b.Grow(len(name))
+	for i := 0; i < len(name); i++ {
+		switch {
+		case name[i] == ':':
+			b.WriteString(internal.EntityEscape(':'))
+		case name[i] == '#' && internal.StartsEntity(name[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(name[i])
+		}
+	}
+	return b.String()
+}

--- a/mermaid/gantt/gantt_chart.go
+++ b/mermaid/gantt/gantt_chart.go
@@ -100,110 +100,110 @@ func (c *Chart) Section(name string) *Chart {
 // startDate can be a date string (e.g., "2024-01-01") or "after taskID".
 // duration can be a duration string (e.g., "30d", "1w") or an end date.
 func (c *Chart) Task(name, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :%s, %s", name, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :%s, %s", escapeTaskName(name), startDate, duration))
 	return c
 }
 
 // TaskWithID adds a task with an ID to the Gantt chart.
 func (c *Chart) TaskWithID(name, id, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :%s, %s, %s", name, id, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :%s, %s, %s", escapeTaskName(name), id, startDate, duration))
 	return c
 }
 
 // CriticalTask adds a critical task to the Gantt chart.
 func (c *Chart) CriticalTask(name, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :crit, %s, %s", name, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :crit, %s, %s", escapeTaskName(name), startDate, duration))
 	return c
 }
 
 // CriticalTaskWithID adds a critical task with an ID to the Gantt chart.
 func (c *Chart) CriticalTaskWithID(name, id, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :crit, %s, %s, %s", name, id, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :crit, %s, %s, %s", escapeTaskName(name), id, startDate, duration))
 	return c
 }
 
 // ActiveTask adds an active task to the Gantt chart.
 func (c *Chart) ActiveTask(name, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :active, %s, %s", name, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :active, %s, %s", escapeTaskName(name), startDate, duration))
 	return c
 }
 
 // ActiveTaskWithID adds an active task with an ID to the Gantt chart.
 func (c *Chart) ActiveTaskWithID(name, id, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :active, %s, %s, %s", name, id, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :active, %s, %s, %s", escapeTaskName(name), id, startDate, duration))
 	return c
 }
 
 // DoneTask adds a done task to the Gantt chart.
 func (c *Chart) DoneTask(name, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :done, %s, %s", name, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :done, %s, %s", escapeTaskName(name), startDate, duration))
 	return c
 }
 
 // DoneTaskWithID adds a done task with an ID to the Gantt chart.
 func (c *Chart) DoneTaskWithID(name, id, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :done, %s, %s, %s", name, id, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :done, %s, %s, %s", escapeTaskName(name), id, startDate, duration))
 	return c
 }
 
 // CriticalActiveTask adds a critical and active task to the Gantt chart.
 func (c *Chart) CriticalActiveTask(name, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :crit, active, %s, %s", name, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :crit, active, %s, %s", escapeTaskName(name), startDate, duration))
 	return c
 }
 
 // CriticalActiveTaskWithID adds a critical and active task with an ID to the Gantt chart.
 func (c *Chart) CriticalActiveTaskWithID(name, id, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :crit, active, %s, %s, %s", name, id, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :crit, active, %s, %s, %s", escapeTaskName(name), id, startDate, duration))
 	return c
 }
 
 // CriticalDoneTask adds a critical and done task to the Gantt chart.
 func (c *Chart) CriticalDoneTask(name, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :crit, done, %s, %s", name, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :crit, done, %s, %s", escapeTaskName(name), startDate, duration))
 	return c
 }
 
 // CriticalDoneTaskWithID adds a critical and done task with an ID to the Gantt chart.
 func (c *Chart) CriticalDoneTaskWithID(name, id, startDate, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :crit, done, %s, %s, %s", name, id, startDate, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :crit, done, %s, %s, %s", escapeTaskName(name), id, startDate, duration))
 	return c
 }
 
 // Milestone adds a milestone to the Gantt chart.
 // A milestone is a task with 0 duration.
 func (c *Chart) Milestone(name, date string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :milestone, %s, 0d", name, date))
+	c.body = append(c.body, fmt.Sprintf("    %s :milestone, %s, 0d", escapeTaskName(name), date))
 	return c
 }
 
 // MilestoneWithID adds a milestone with an ID to the Gantt chart.
 func (c *Chart) MilestoneWithID(name, id, date string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :milestone, %s, %s, 0d", name, id, date))
+	c.body = append(c.body, fmt.Sprintf("    %s :milestone, %s, %s, 0d", escapeTaskName(name), id, date))
 	return c
 }
 
 // CriticalMilestone adds a critical milestone to the Gantt chart.
 func (c *Chart) CriticalMilestone(name, date string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :crit, milestone, %s, 0d", name, date))
+	c.body = append(c.body, fmt.Sprintf("    %s :crit, milestone, %s, 0d", escapeTaskName(name), date))
 	return c
 }
 
 // CriticalMilestoneWithID adds a critical milestone with an ID to the Gantt chart.
 func (c *Chart) CriticalMilestoneWithID(name, id, date string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :crit, milestone, %s, %s, 0d", name, id, date))
+	c.body = append(c.body, fmt.Sprintf("    %s :crit, milestone, %s, %s, 0d", escapeTaskName(name), id, date))
 	return c
 }
 
 // TaskAfter adds a task that starts after another task.
 func (c *Chart) TaskAfter(name, afterTaskID, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :after %s, %s", name, afterTaskID, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :after %s, %s", escapeTaskName(name), afterTaskID, duration))
 	return c
 }
 
 // TaskAfterWithID adds a task with ID that starts after another task.
 func (c *Chart) TaskAfterWithID(name, id, afterTaskID, duration string) *Chart {
-	c.body = append(c.body, fmt.Sprintf("    %s :%s, after %s, %s", name, id, afterTaskID, duration))
+	c.body = append(c.body, fmt.Sprintf("    %s :%s, after %s, %s", escapeTaskName(name), id, afterTaskID, duration))
 	return c
 }
 

--- a/mermaid/gantt/gantt_chart_test.go
+++ b/mermaid/gantt/gantt_chart_test.go
@@ -512,3 +512,80 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestTaskNameEscapesTheColonThatEndsIt names the character this escaping buys.
+// A gantt task is written "name :data" and mermaid splits the line at the first
+// colon, so a colon in the name used to end it early: the chart still drew, with
+// a task called "Deploy" where the caller asked for "Deploy: staging". Nothing
+// reported it, which is what makes it worth fixing.
+func TestTaskNameEscapesTheColonThatEndsIt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(*Chart) *Chart
+		want  string
+	}{
+		"a colon in a plain task": {
+			build: func(g *Chart) *Chart {
+				return g.Task("Deploy: staging", "2024-01-01", "2d")
+			},
+			want: "    Deploy#58; staging :2024-01-01, 2d",
+		},
+		"a colon in a critical task": {
+			build: func(g *Chart) *Chart {
+				return g.CriticalTask("a:b", "2024-01-01", "2d")
+			},
+			want: "    a#58;b :crit, 2024-01-01, 2d",
+		},
+		"a colon in a milestone": {
+			build: func(g *Chart) *Chart {
+				return g.Milestone("a:b", "2024-01-01")
+			},
+			want: "    a#58;b :milestone, 2024-01-01, 0d",
+		},
+		"a colon in a task that follows another": {
+			build: func(g *Chart) *Chart {
+				return g.TaskAfter("a:b", "t1", "2d")
+			},
+			want: "    a#58;b :after t1, 2d",
+		},
+		"a named entity in a task name is escaped": {
+			build: func(g *Chart) *Chart {
+				return g.Task("a#quot;b", "2024-01-01", "2d")
+			},
+			want: "    a#35;quot;b :2024-01-01, 2d",
+		},
+		"a plain hash in a task name is left alone": {
+			build: func(g *Chart) *Chart {
+				return g.Task("PR #123 merged", "2024-01-01", "2d")
+			},
+			want: "    PR #123 merged :2024-01-01, 2d",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(NewChart(io.Discard)).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("chart =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSectionAndTitleKeepTheirColon pins the other half: mermaid reads each of
+// those as the rest of its line, so a colon in one already reaches the drawing
+// and escaping it would change output that is correct today.
+func TestSectionAndTitleKeepTheirColon(t *testing.T) {
+	t.Parallel()
+
+	got := NewChart(io.Discard, WithTitle("Q1: plan")).Section("Ops: core").String()
+
+	for _, want := range []string{"    title Q1: plan", "    section Ops: core"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("chart =\n%s\nwant it to contain\n%s", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `gantt`.

## The defect

A gantt task is written `name :data`, and mermaid splits the line at the **first** colon. A colon inside the name ended it early and the rest became task data.

Worth being precise about the failure mode, because it is not the one the issue's table describes: the chart **still draws**. A caller asking for `Deploy: staging` got a task called `Deploy`. Nothing errors, nothing is missing from the page, and the reader has no way to tell the picture is not the one that was asked for. That is quieter, and worse, than a diagram that is lost.

## The fix

mermaid reads its own entity form in a task name, so a `:` is written `#58;` and reaches the drawing as a colon. Applied to all eighteen task-writing methods (plain, critical, active, done, their combinations, milestones, `TaskAfter`, and the `WithID` variants).

A `#` that would start an entity is escaped with it, so a name holding `#58;` stays distinguishable from one holding a colon. A `#` anywhere else — `PR #123 merged` — comes out byte for byte as before.

## What is deliberately not touched

The **section name** and the **title**. mermaid reads each as the rest of its line, so a colon in one already reaches the drawing intact; escaping there would change output that is correct today. `TestSectionAndTitleKeepTheirColon` pins that, so a later well-meaning sweep does not "fix" them.

## Verification

- `go test ./...` passes with **no golden file changed**; `golangci-lint run ./...` reports 0 issues.
- `mermaid/gantt` coverage 98.9%.
- The `gantt` entry in `doc/edgecase/main.go` widens to the full probe set and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.