### PR TITLE
fix(mermaid): escape the colon and semicolon that end a class statement

### DIFF
--- a/doc/edgecase/class.md
+++ b/doc/edgecase/class.md
@@ -4,14 +4,14 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 ---
-title: "title \"'#[](){}🎉日本語,*-|%%"
+title: "title \"'#;[](){}🎉日本語:,*-|%%"
 ---
 classDiagram
     class Account {
         +string id
     }
-    class Ledger["before &quot;'#[](){}🎉日本語,*-|%% after"]
+    class Ledger["before &quot;'#;[](){}🎉日本語:,*-|%% after"]
     Account --> Ledger
-    Account ..> Ledger : x"'#[](){}🎉日本語,*-|%%x
-    note for Account "before &quot;'#[](){}🎉日本語,*-|%% after"
+    Account ..> Ledger : x"'##59;[](){}🎉日本語#58;,*-|%%x
+    note for Account "before &quot;'#;[](){}🎉日本語:,*-|%% after"
 ```

--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -76,8 +76,9 @@ func supported(diagram string) string {
 		// every character below survives both. Only a line break is left out:
 		// one macro is one line, and "<br/>" is how a label breaks one.
 		"c4": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%\`,
-		// class: ";" and ":" end a relation label.
-		"class": `"'#[](){}` + emoji + japanese + `,*-|%%`,
+		// class writes the ";" and the ":" that would end a relation label as
+		// the entity form mermaid decodes, so the punctuation is all safe.
+		"class": `"'#;[](){}` + emoji + japanese + `:,*-|%%`,
 		// er writes a comment as the entity form mermaid decodes, so the
 		// punctuation is all safe.
 		"er": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,

--- a/mermaid/class/class_diagram.go
+++ b/mermaid/class/class_diagram.go
@@ -336,7 +336,7 @@ type SourceRelationBuilder struct {
 
 // Member adds a member using Class : Member syntax.
 func (d *Diagram) Member(className, member string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s : %s", className, member))
+	d.body = append(d.body, fmt.Sprintf("    %s : %s", className, escapeAfterColon(member)))
 	return d
 }
 
@@ -494,7 +494,7 @@ func (d *Diagram) AssociationWithCardinalityAndLabel(
 func (d *Diagram) RelationWithLabel(from string, relationship Relationship, to, label string) *Diagram {
 	d.body = append(
 		d.body,
-		fmt.Sprintf("    %s %s %s : %s", from, relationship, to, label),
+		fmt.Sprintf("    %s %s %s : %s", from, relationship, to, escapeAfterColon(label)),
 	)
 	return d
 }
@@ -531,7 +531,7 @@ func (d *Diagram) RelationWithCardinalityAndLabel(
 			relationship,
 			quote(toCardinality),
 			to,
-			label,
+			escapeAfterColon(label),
 		),
 	)
 	return d

--- a/mermaid/class/class_diagram_test.go
+++ b/mermaid/class/class_diagram_test.go
@@ -650,3 +650,94 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestRelationLabelEscapesTheCharactersThatEndTheStatement names the two
+// characters this escaping buys. The "A --> B : label" and "A : member" lines
+// are the only unquoted text a class diagram takes, and a colon or a semicolon
+// in one ended the statement: mermaid refused the whole diagram and the reader
+// got an error box rather than a picture.
+func TestRelationLabelEscapesTheCharactersThatEndTheStatement(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(*Diagram) *Diagram
+		want  string
+	}{
+		"a colon in a relation label": {
+			build: func(d *Diagram) *Diagram {
+				return d.RelationWithLabel("A", RelationshipAssociation, "B", "owns: many")
+			},
+			want: "    A --> B : owns#58; many",
+		},
+		"a semicolon in a relation label": {
+			build: func(d *Diagram) *Diagram {
+				return d.RelationWithLabel("A", RelationshipAssociation, "B", "a;b")
+			},
+			want: "    A --> B : a#59;b",
+		},
+		"a colon in a relation label with cardinality": {
+			build: func(d *Diagram) *Diagram {
+				return d.RelationWithCardinalityAndLabel("A", "1", RelationshipAssociation, "B", "*", "a:b")
+			},
+			want: `    A "1" --> "*" B : a#58;b`,
+		},
+		"a colon in a member": {
+			build: func(d *Diagram) *Diagram {
+				return d.Member("A", "start: time.Time")
+			},
+			want: "    A : start#58; time.Time",
+		},
+		"a named entity in a label is escaped": {
+			build: func(d *Diagram) *Diagram {
+				return d.RelationWithLabel("A", RelationshipAssociation, "B", "a#58;b")
+			},
+			want: "    A --> B : a#35;58#59;b",
+		},
+		"a plain hash in a label is left alone": {
+			build: func(d *Diagram) *Diagram {
+				return d.RelationWithLabel("A", RelationshipAssociation, "B", "PR #123 merged")
+			},
+			want: "    A --> B : PR #123 merged",
+		},
+		"a hash beside a semicolon keeps both": {
+			// The "#" starts no entity, so it stays; the ";" becomes one. The
+			// "##59;" that comes out reads back as "#" then ";", because
+			// mermaid finds the entity at the second "#".
+			build: func(d *Diagram) *Diagram {
+				return d.RelationWithLabel("A", RelationshipAssociation, "B", "a#;b")
+			},
+			want: "    A --> B : a##59;b",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(NewDiagram(io.Discard)).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestQuotedTextKeepsItsColonAndSemicolon pins the other half: everywhere else
+// in a class diagram is already quoted, and a class body member, a class label
+// and a note each take both characters as they are. Escaping there would change
+// output that is correct today.
+func TestQuotedTextKeepsItsColonAndSemicolon(t *testing.T) {
+	t.Parallel()
+
+	got := NewDiagram(io.Discard).
+		ClassWithLabel("A", "a:b;c").
+		Note("a:b;c").
+		NoteFor("A", "a:b;c").
+		String()
+
+	for _, want := range []string{`class A["a:b;c"]`, `note "a:b;c"`, `note for A "a:b;c"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, want)
+		}
+	}
+}

--- a/mermaid/class/escape.go
+++ b/mermaid/class/escape.go
@@ -11,7 +11,7 @@ import (
 //
 // Those two lines are the only unquoted text a class diagram takes, and mermaid
 // reads a colon or a semicolon in them as the end of the statement. Either one
-// makes it refuse the whole diagram, so a relationship labelled "owns: many"
+// makes it refuse the whole diagram, so a relationship labeled "owns: many"
 // left the reader an error box instead of a picture.
 //
 // Both are written as the entity form mermaid decodes, which was found by

--- a/mermaid/class/escape.go
+++ b/mermaid/class/escape.go
@@ -1,0 +1,45 @@
+package class
+
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+// escapeAfterColon returns text ready to be written after the colon in the
+// "A --> B : label" and "A : member" forms.
+//
+// Those two lines are the only unquoted text a class diagram takes, and mermaid
+// reads a colon or a semicolon in them as the end of the statement. Either one
+// makes it refuse the whole diagram, so a relationship labelled "owns: many"
+// left the reader an error box instead of a picture.
+//
+// Both are written as the entity form mermaid decodes, which was found by
+// rendering. A "#" that would start an entity is escaped with them, or a label
+// holding "#58;" and a label holding a colon would draw the same diagram; a "#"
+// anywhere else is ordinary text and comes out unchanged.
+//
+// Everywhere else in this package is already quoted, and a class body member, a
+// class label and a note each take both characters as they are. Nothing here
+// touches those.
+func escapeAfterColon(text string) string {
+	if !strings.ContainsAny(text, ":;#") {
+		return text
+	}
+
+	var b strings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		switch {
+		case text[i] == ':':
+			b.WriteString(internal.EntityEscape(':'))
+		case text[i] == ';':
+			b.WriteString(internal.EntityEscape(';'))
+		case text[i] == '#' && internal.StartsEntity(text[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(text[i])
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `class`.

## The defect

`A --> B : label` and `A : member` are the only **unquoted** text a class diagram takes. mermaid reads a `:` or a `;` in either as the end of the statement, and refuses the whole diagram. A relationship labelled `owns: many` left the reader an error box instead of a picture.

## The fix

Both characters are written as the entity form mermaid decodes — `#58;` and `#59;` — in `RelationWithLabel`, `RelationWithCardinalityAndLabel`, the association helper that funnels into it, and `Member`.

A `#` that would start an entity is escaped with them, so a label holding `#58;` stays distinguishable from one holding a colon.

There is one interaction worth pointing out, because it looks wrong at a glance and is tested: a label `a#;b` comes out as `a##59;b`. The `#` starts no entity so it stays; the `;` becomes one; and mermaid finds the entity at the *second* `#`, so it draws `a#;b`. Verified against the renderer, both directions.

## What is deliberately not touched

Everywhere else in a class diagram is already quoted, and a class body member, a class label and a note each take `:` and `;` as they are. `TestQuotedTextKeepsItsColonAndSemicolon` pins that, so a later sweep does not "fix" them and move output that is correct today.

## Verification

- `go test ./...` passes with **no golden file changed**; `golangci-lint run ./...` reports 0 issues.
- `mermaid/class` coverage 98.2%.
- The `class` entry in `doc/edgecase/main.go` gains `;` and `:` and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved class diagram rendering for members and relationship labels containing colons, semicolons, and entity-like hash characters.
  * Preserved punctuation in quoted labels and notes while safely escaping it in unquoted text.
* **Tests**
  * Added coverage for punctuation, entity-like hashes, plain hashes, and combinations of these characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->