### PR TITLE
fix(mermaid): escape each user journey field's own punctuation

### DIFF
--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -131,9 +131,10 @@ func supported(diagram string) string {
 		// backslash, because it is the only one whose quoting was proven to
 		// leave one alone.
 		"treemap": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%\`,
-		// userjourney: "#" and ";" end a statement, and ":" separates the
-		// fields of a task.
-		"userjourney": `"'[](){}<br/>` + emoji + japanese + `,*-|%%`,
+		// userjourney writes the punctuation each of its unquoted fields would
+		// otherwise lose as the entity form mermaid decodes, so the
+		// punctuation is all safe.
+		"userjourney": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
 		// xychart: an axis label is written unquoted, so non-ASCII breaks it.
 		"xychart": `"'#;[](){}` + emoji + `:,*-|%%`,
 	}[diagram]

--- a/doc/edgecase/userjourney.md
+++ b/doc/edgecase/userjourney.md
@@ -4,7 +4,7 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 journey
-    title title "'[](){}🎉日本語,*-|%%
-    section x"'[](){}<br/>🎉日本語,*-|%%x
-        x"'[](){}<br/>🎉日本語,*-|%%x: 4: x"'[](){}<br/>🎉日本語,*-|%%x
+    title title "'#35;#59;[](){}🎉日本語:,*-|%%
+    section x"'##59;[](){}<br/>🎉日本語#58;,*-|%%x
+        x"'#35;#59;[](){}<br/>🎉日本語#58;,*-|%%x: 4: x"'##59;[](){}<br/>🎉日本語#58;#44;*-|%%x
 ```

--- a/mermaid/userjourney/escape.go
+++ b/mermaid/userjourney/escape.go
@@ -1,0 +1,68 @@
+package userjourney
+
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+// A user journey is written entirely in unquoted text: a title is the rest of
+// its line, a section is the rest of its line, and a task is
+// "name: score: actor, actor". There is nowhere to put a quotation mark, so
+// each field's own punctuation has to be written as the entity form mermaid
+// decodes. What that punctuation is differs by field, and each set below was
+// measured by rendering one character at a time.
+const (
+	// titleUnsafe is what a title cannot carry. A semicolon ends the statement
+	// and loses the whole diagram; a "#" starts a comment, and the title is
+	// then quietly cut short at it rather than the diagram failing.
+	titleUnsafe = "#;"
+	// sectionUnsafe is what a section name cannot carry. A colon loses the
+	// diagram here, unlike in a title, and a "#" is safe here, unlike in one.
+	sectionUnsafe = ";:"
+	// taskUnsafe is what a task name cannot carry. A "#" starts a comment and
+	// loses the diagram, and a colon ends the name: the diagram still draws
+	// then, with the rest of the name read as the score.
+	taskUnsafe = "#;:"
+	// actorUnsafe is what one actor's name cannot carry. A comma separates one
+	// actor from the next, so a comma inside a name quietly splits it in two.
+	actorUnsafe = ";:,"
+)
+
+// escapeField returns text ready to be written into a field that cannot carry
+// the characters in unsafe.
+//
+// A "#" is escaped whenever it would start an entity, whether or not the field
+// lists it: this package writes entities, so a caller's literal "#59;" has to
+// come out different from a caller's semicolon. A "#" that starts nothing is
+// left alone in the fields that can hold one, which is what keeps output that
+// already renders unchanged.
+func escapeField(text, unsafe string) string {
+	if !strings.ContainsAny(text, unsafe+"#") {
+		return text
+	}
+
+	var b strings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		switch {
+		case strings.IndexByte(unsafe, text[i]) >= 0:
+			b.WriteString(internal.EntityEscape(rune(text[i])))
+		case text[i] == '#' && internal.StartsEntity(text[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(text[i])
+		}
+	}
+	return b.String()
+}
+
+// escapeActors returns each actor ready to be written into the comma separated
+// list a task ends with.
+func escapeActors(actors []string) []string {
+	escaped := make([]string, 0, len(actors))
+	for _, actor := range actors {
+		escaped = append(escaped, escapeField(actor, actorUnsafe))
+	}
+	return escaped
+}

--- a/mermaid/userjourney/user_journey.go
+++ b/mermaid/userjourney/user_journey.go
@@ -57,7 +57,7 @@ func NewDiagram(w io.Writer, opts ...Option) *Diagram {
 
 	lines := []string{"journey"}
 	if c.title != noTitle {
-		lines = append(lines, fmt.Sprintf("    title %s", c.title))
+		lines = append(lines, fmt.Sprintf("    title %s", escapeField(c.title, titleUnsafe)))
 	}
 
 	return &Diagram{
@@ -113,7 +113,7 @@ func (d *Diagram) Section(name string) *Diagram {
 	}
 
 	d.currentSection = trimmed
-	d.body = append(d.body, fmt.Sprintf("    section %s", trimmed))
+	d.body = append(d.body, fmt.Sprintf("    section %s", escapeField(trimmed, sectionUnsafe)))
 	return d
 }
 
@@ -158,9 +158,9 @@ func (d *Diagram) Task(name string, score Score, actors ...string) *Diagram {
 		return d
 	}
 
-	taskLine := fmt.Sprintf("        %s: %d", trimmedName, score)
+	taskLine := fmt.Sprintf("        %s: %d", escapeField(trimmedName, taskUnsafe), score)
 	if len(trimmedActors) > 0 {
-		taskLine = fmt.Sprintf("%s: %s", taskLine, strings.Join(trimmedActors, ", "))
+		taskLine = fmt.Sprintf("%s: %s", taskLine, strings.Join(escapeActors(trimmedActors), ", "))
 	}
 
 	d.body = append(d.body, taskLine)

--- a/mermaid/userjourney/user_journey_test.go
+++ b/mermaid/userjourney/user_journey_test.go
@@ -400,3 +400,72 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestFieldsEscapeTheirOwnPunctuation names the characters this escaping buys.
+// A user journey is written entirely in unquoted text, so each of its four
+// fields loses a different set of characters, and each set below was measured
+// by rendering one character at a time.
+func TestFieldsEscapeTheirOwnPunctuation(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(io.Writer) *Diagram
+		want  string
+	}{
+		"a semicolon in a title loses the diagram": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w, WithTitle("a;b")) },
+			want:  "    title a#59;b",
+		},
+		"a hash in a title cuts it short": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w, WithTitle("PR #12")) },
+			want:  "    title PR #35;12",
+		},
+		"a semicolon and a colon in a section": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Section("a;b:c") },
+			want:  "    section a#59;b#58;c",
+		},
+		"a hash in a section is left alone": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Section("PR #12") },
+			want:  "    section PR #12",
+		},
+		"a hash, a semicolon and a colon in a task name": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Section("S").Task("a#b;c:d", ScoreSatisfied)
+			},
+			want: "        a#35;b#59;c#58;d: 4",
+		},
+		"a comma in an actor splits it in two": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Section("S").Task("t", ScoreSatisfied, "Ops, EU")
+			},
+			want: "        t: 4: Ops#44; EU",
+		},
+		"actors are still separated by a comma": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Section("S").Task("t", ScoreSatisfied, "Ops", "EU")
+			},
+			want: "        t: 4: Ops, EU",
+		},
+		"a comma in a task name is left alone": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Section("S").Task("a,b", ScoreSatisfied)
+			},
+			want: "        a,b: 4",
+		},
+		"a named entity is escaped wherever entities are written": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Section("a#59;b") },
+			want:  "    section a#35;59#59;b",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(io.Discard).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `userjourney`.

## Why this one has four escape sets rather than one

A user journey is written entirely in **unquoted** text — a title is the rest of its line, a section is the rest of its line, a task is `name: score: actor, actor`. There is nowhere to put a quotation mark, so each field loses a different set of characters. Measured by rendering one character at a time:

| field | loses | what happens |
|---|---|---|
| title | `;` | whole diagram refused |
| title | `#` | opens a comment — **title quietly cut short**, diagram still draws |
| section | `;` `:` | whole diagram refused |
| task name | `;` `#` | whole diagram refused |
| task name | `:` | ends the name — **rest read as the score**, diagram still draws |
| actor | `;` `:` | whole diagram refused |
| actor | `,` | **splits one actor into two**, diagram still draws |

The last row is the one worth pausing on. `Task("t", ScoreSatisfied, "Ops, EU")` drew *two* actors, `Ops` and `EU`. The render harness in #125 could never have caught it: the picture draws fine and simply names somebody who was never asked for.

## The fix

Each field writes exactly its own set as the entity form mermaid decodes, and nothing more:

- A `#` stays as it is in a **section name** and in an **actor**, because it reaches the drawing there. Only the title and the task name escape it.
- A `,` stays as it is in a **task name**. Only an actor escapes it, and the comma the builder writes *between* actors is still a separator — tested both ways.
- A `#` that would start an entity is escaped everywhere entities are written, so a caller's literal `#59;` stays distinguishable from a caller's semicolon.

## Verification

- `go test ./...` passes with **no golden file changed**; `golangci-lint run ./...` reports 0 issues.
- `mermaid/userjourney` coverage 97.0%.
- The `userjourney` entry in `doc/edgecase/main.go` widens to the full probe set and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.