### PR TITLE
fix(mermaid): quote an xy chart label that is not an ASCII word

### DIFF
--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -137,8 +137,10 @@ func supported(diagram string) string {
 		// otherwise lose as the entity form mermaid decodes, so the
 		// punctuation is all safe.
 		"userjourney": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
-		// xychart: an axis label is written unquoted, so non-ASCII breaks it.
-		"xychart": `"'#;[](){}` + emoji + `:,*-|%%`,
+		// xychart quotes any label that is not an ASCII word, and a quoted one
+		// takes non-ASCII text as readily as ASCII. A line break is left out
+		// because the renderer honors "<br/>" inside a label.
+		"xychart": `"'#;[](){}` + emoji + japanese + `:,*-|%%`,
 	}[diagram]
 }
 

--- a/doc/edgecase/xychart.md
+++ b/doc/edgecase/xychart.md
@@ -4,9 +4,9 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 xychart
-    title "title &quot;'#;[](){}🎉:,*-|%%"
-    x-axis "x&quot;'#;[](){}🎉:,*-|%%x" ["x&quot;'#;[](){}🎉:,*-|%%x", "x&quot;'#;[](){}🎉:,*-|%%x two"]
-    y-axis "x&quot;'#;[](){}🎉:,*-|%%x" 0 --> 100
+    title "title &quot;'#;[](){}🎉日本語:,*-|%%"
+    x-axis "x&quot;'#;[](){}🎉日本語:,*-|%%x" ["x&quot;'#;[](){}🎉日本語:,*-|%%x", "x&quot;'#;[](){}🎉日本語:,*-|%%x two"]
+    y-axis "x&quot;'#;[](){}🎉日本語:,*-|%%x" 0 --> 100
     bar [10, 20]
     line [30, 40]
 ```

--- a/mermaid/xychart/xy_chart.go
+++ b/mermaid/xychart/xy_chart.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/nao1215/markdown/internal"
 )
@@ -341,8 +340,17 @@ func shouldQuote(value string) bool {
 	return false
 }
 
+// isIdentifierChar reports whether r may appear in a token this package leaves
+// unquoted.
+//
+// The set is ASCII on purpose. mermaid's xy chart grammar takes only ASCII word
+// characters in an unquoted token, so a label of Japanese text written without
+// quotes made it refuse the whole chart. unicode.IsLetter said such a label
+// needed no quotes, which is why an emoji reached the drawing and a word of
+// Japanese did not: the emoji is not a letter and was quoted anyway.
 func isIdentifierChar(r rune) bool {
-	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.'
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+		r == '_' || r == '-' || r == '.'
 }
 
 func isKeyword(value string) bool {

--- a/mermaid/xychart/xy_chart_test.go
+++ b/mermaid/xychart/xy_chart_test.go
@@ -472,3 +472,61 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestQuotedLabelsCarryNonASCII pins what the edge case document now claims.
+// The measurement in doc/edgecase/main.go used to say an xy chart loses the
+// diagram on Japanese text; it does not, because every label and the title go
+// out quoted and a quoted label takes non-ASCII as readily as ASCII. This test
+// is the fast half of the check and the rendered document is the real one.
+func TestQuotedLabelsCarryNonASCII(t *testing.T) {
+	t.Parallel()
+
+	got := NewDiagram(io.Discard, WithTitle("日本語 🎉")).
+		XAxisLabelsWithTitle("日本語", "日本語", "🎉").
+		YAxisRangeWithTitle("日本語 🎉", 0, 100).
+		Bar(10, 20).
+		String()
+
+	want := []string{
+		`    title "日本語 🎉"`,
+		`    x-axis "日本語" ["日本語", "🎉"]`,
+		`    y-axis "日本語 🎉" 0 --> 100`,
+	}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("chart =\n%s\nwant it to contain\n%s", got, w)
+		}
+	}
+}
+
+// TestNonASCIILabelsAreQuoted names what this buys. mermaid's xy chart grammar
+// takes only ASCII word characters in an unquoted token, and a plain word of
+// Japanese used to be written without quotes because unicode.IsLetter said it
+// needed none. mermaid then refused the whole chart. An emoji was quoted all
+// along, which is why one reached the drawing and the other did not.
+func TestNonASCIILabelsAreQuoted(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		label string
+		want  string
+	}{
+		"an ASCII word stays unquoted":     {label: "Sales", want: `    x-axis Sales [a]`},
+		"a word with a dot stays unquoted": {label: "v1.2-rc_3", want: `    x-axis v1.2-rc_3 [a]`},
+		"Japanese is quoted":               {label: "日本語", want: `    x-axis "日本語" [a]`},
+		"an emoji is quoted":               {label: "🎉", want: `    x-axis "🎉" [a]`},
+		"a Cyrillic word is quoted":        {label: "Продажи", want: `    x-axis "Продажи" [a]`},
+		"an accented word is quoted":       {label: "Café", want: `    x-axis "Café" [a]`},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := NewDiagram(io.Discard).XAxisLabelsWithTitle(tt.label, "a").String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("chart =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `xychart`.

## The defect, and why it looked so odd in the measurement

The issue records `xychart` as losing the diagram on "any non-ASCII text, for example Japanese" — while listing an emoji as fine. That asymmetry is the clue.

This package quotes a token only when it has to, and decided with `unicode.IsLetter`:

```go
func isIdentifierChar(r rune) bool {
	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.'
}
```

`日本語` is three letters by that test, so it went out **unquoted** — and mermaid's xy chart grammar takes only ASCII word characters in an unquoted token, so it refused the whole chart. `🎉` is not a letter, so it was quoted all along and drew fine.

## The fix

The identifier set is now ASCII. Anything else gets quoted, and a quoted label carries non-ASCII as readily as ASCII — verified against the renderer.

An ASCII label is untouched: `Sales` and `v1.2-rc_3` still go out bare, so no golden file and no documentation sample moves. Cyrillic and accented Latin (`Продажи`, `Café`) were broken by the same rule and are fixed by the same line; both are tested.

## Verification

- `go test ./...` passes with **no golden file changed**; `golangci-lint run ./...` reports 0 issues.
- `mermaid/xychart` coverage 95.5%.
- The `xychart` entry in `doc/edgecase/main.go` gains Japanese and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.

While here I also re-measured `sankey` (non-ASCII) and `packet` (`%%`) against the current renderer, in case those entries were stale too. They are not — both still fail — so they stay as they are and keep their own pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XY chart handling for non-ASCII text, including Japanese, emoji, Cyrillic, and accented characters.
  * Non-ASCII titles, axis titles, and labels are now correctly quoted for reliable rendering.
  * Preserved support for unquoted ASCII-compatible labels and special characters.

* **Tests**
  * Added coverage for multilingual and non-ASCII XY chart content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->