### PR TITLE
fix(mermaid): escape the shape delimiters that lose a mindmap

### DIFF
--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -94,8 +94,10 @@ func supported(diagram string) string {
 		// kanban: quotes end the single quoted metadata, and square brackets
 		// and a closing brace end a node.
 		"kanban": `#;{<br/>` + emoji + japanese + `:,*-|%%`,
-		// mindmap: brackets, parentheses and braces are node shape delimiters.
-		"mindmap": `"'#;]<br/>` + emoji + japanese + `:,*-|%%`,
+		// mindmap writes the brackets, parentheses and braces that delimit a
+		// node shape as the entity form mermaid decodes, so the punctuation is
+		// all safe.
+		"mindmap": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
 		// packet and piechart put the title in YAML front matter, and mermaid
 		// strips a "%%" comment from that before the YAML is read.
 		"packet": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|`,

--- a/doc/edgecase/mindmap.md
+++ b/doc/edgecase/mindmap.md
@@ -4,10 +4,10 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 ---
-title: "title \"'#;]🎉日本語:,*-|%%"
+title: "title \"'#;[](){}🎉日本語:,*-|%%"
 ---
 mindmap
-    x"'#;]<br/>🎉日本語:,*-|%%x
-        x"'#;]<br/>🎉日本語:,*-|%%x
-        x"'#;]<br/>🎉日本語:,*-|%%x
+    x"'#;#91;]#40;#41;#123;#125;<br/>🎉日本語:,*-|%%x
+        x"'#;#91;]#40;#41;#123;#125;<br/>🎉日本語:,*-|%%x
+        x"'#;#91;]#40;#41;#123;#125;<br/>🎉日本語:,*-|%%x
 ```

--- a/mermaid/mindmap/escape.go
+++ b/mermaid/mindmap/escape.go
@@ -1,0 +1,45 @@
+package mindmap
+
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+// shapeDelimiters are the characters that open or close a mindmap node shape.
+//
+// A mindmap node is unquoted text, and mermaid reads these as the start or the
+// end of the shape around it: "root(text)" is a rounded node and "root[text]" a
+// square one. One of them inside the text loses the whole diagram, which is
+// exactly what a node saying "Deploy (staging)" did.
+//
+// A closing bracket is not here. mermaid accepts one on its own, since nothing
+// opened, and escaping it would change output that already reaches the drawing.
+const shapeDelimiters = "[(){}"
+
+// escapeText returns text ready to be written as a mindmap node.
+//
+// The delimiters above are written as the entity form mermaid decodes, which
+// was found by rendering each one. A "#" that would start an entity is escaped
+// with them, or a node holding "#40;" and a node holding an opening parenthesis
+// would draw the same picture; a "#" anywhere else is ordinary text and comes
+// out unchanged.
+func escapeText(text string) string {
+	if !strings.ContainsAny(text, shapeDelimiters+"#") {
+		return text
+	}
+
+	var b strings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		switch {
+		case strings.IndexByte(shapeDelimiters, text[i]) >= 0:
+			b.WriteString(internal.EntityEscape(rune(text[i])))
+		case text[i] == '#' && internal.StartsEntity(text[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(text[i])
+		}
+	}
+	return b.String()
+}

--- a/mermaid/mindmap/mindmap.go
+++ b/mermaid/mindmap/mindmap.go
@@ -137,7 +137,7 @@ func (d *Diagram) Node(level int, text string) *Diagram {
 		}
 	}
 
-	line := fmt.Sprintf("%s%s", strings.Repeat("    ", level+1), trimmedText)
+	line := fmt.Sprintf("%s%s", strings.Repeat("    ", level+1), escapeText(trimmedText))
 	d.body = append(d.body, line)
 	d.currentLevel = level
 	if level == 0 {

--- a/mermaid/mindmap/mindmap_test.go
+++ b/mermaid/mindmap/mindmap_test.go
@@ -387,3 +387,57 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestNodeTextEscapesTheShapeDelimiters names the characters this escaping
+// buys. A mindmap node is unquoted text and mermaid reads a bracket, a
+// parenthesis or a brace in it as the shape around the node, so a node saying
+// "Deploy (staging)" lost the whole diagram: the reader got an error box rather
+// than a picture.
+func TestNodeTextEscapesTheShapeDelimiters(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(io.Writer) *Diagram
+		want  string
+	}{
+		"parentheses in a root": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Root("Deploy (staging)") },
+			want:  "    Deploy #40;staging#41;",
+		},
+		"square brackets in a child": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Root("r").Child("a[b") },
+			want:  "        a#91;b",
+		},
+		"braces in a sibling": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Root("r").Child("a").Sibling("{x}")
+			},
+			want: "        #123;x#125;",
+		},
+		"a closing bracket alone is left as it is": {
+			// mermaid takes one on its own, since nothing opened, so escaping
+			// it would change output that already reaches the drawing.
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Root("a]b") },
+			want:  "    a]b",
+		},
+		"a named entity is escaped": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Root("a#40;b") },
+			want:  "    a#35;40;b",
+		},
+		"a plain hash is left alone": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Root("PR #123 merged") },
+			want:  "    PR #123 merged",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(io.Discard).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `mindmap`.

## The defect

A mindmap node is unquoted text, and mermaid reads a bracket, parenthesis or brace in it as the **shape** around the node — `root(text)` is rounded, `root[text]` is square. One inside the text loses the whole diagram.

`Child("Deploy (staging)")` is all it took.

## The fix

Each of `[`, `(`, `)`, `{`, `}` is written as the entity form mermaid decodes, found by rendering them one at a time.

A closing `]` is deliberately **not** among them: mermaid accepts one on its own, since nothing opened, and escaping it would change output that already reaches the drawing. The `supported` map already listed it, and it stays listed.

A `#` that would start an entity is escaped with them, so a node holding `#40;` stays distinguishable from one holding an opening parenthesis. A `#` anywhere else — `PR #123 merged` — comes out byte for byte as before.

## Verification

- `go test ./...` passes with **no golden file changed**; `golangci-lint run ./...` reports 0 issues.
- `mermaid/mindmap` coverage 93.9%.
- The `mindmap` entry in `doc/edgecase/main.go` widens to the full probe set and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.