### PR TITLE
fix(mermaid): encode a kanban card label instead of rejecting it

### DIFF
--- a/doc/edgecase/kanban.md
+++ b/doc/edgecase/kanban.md
@@ -4,9 +4,9 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 ---
-title: "title #;{🎉日本語:,*-|%%"
+title: "title \"'#;[](){}🎉日本語:,*-|%%"
 ---
 kanban
-    todo[x#;{<br/>🎉日本語:,*-|%%x]
-        [before #;{<br/>🎉日本語:,*-|%% after]@{ assigned: 'x#;{<br/>🎉日本語:,*-|%%x', priority: 'High' }
+    todo[x"'#;[#93;#40;#41;{#125;<br/>🎉日本語:,*-|%%x]
+        [before "'#;[#93;#40;#41;{#125;<br/>🎉日本語:,*-|%% after]@{ assigned: 'x#quot;''#;[](){#125;<br/>🎉日本語:,*-|%%x', priority: 'High' }
 ```

--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -91,9 +91,11 @@ func supported(diagram string) string {
 		// the entity form mermaid decodes, so the punctuation is all safe.
 		"gantt":    `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
 		"gitgraph": `"'#;[](){}` + emoji + japanese + `:,*-|%%`,
-		// kanban: quotes end the single quoted metadata, and square brackets
-		// and a closing brace end a node.
-		"kanban": `#;{<br/>` + emoji + japanese + `:,*-|%%`,
+		// kanban writes the punctuation that would end a card label, and the
+		// punctuation the kanban lexer takes out of a metadata value before
+		// YAML sees it, as the entity form mermaid decodes. A single quote in
+		// metadata is doubled instead, because that is YAML's own escape.
+		"kanban": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
 		// mindmap writes the brackets, parentheses and braces that delimit a
 		// node shape as the entity form mermaid decodes, so the punctuation is
 		// all safe.

--- a/mermaid/kanban/escape.go
+++ b/mermaid/kanban/escape.go
@@ -1,0 +1,75 @@
+package kanban
+
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+// labelUnsafe is what a card label cannot carry.
+//
+// A card is written "id[label]", and mermaid ends the label at the first "]".
+// A parenthesis or a closing brace ends it too, because the shapes those spell
+// elsewhere in mermaid are recognized here. An opening bracket and an opening
+// brace are not among them: mermaid takes either inside a label, and escaping
+// them would change output that already reaches the drawing.
+const labelUnsafe = "])(}"
+
+// metadataUnsafe is what a metadata value cannot carry, beyond the quoting the
+// YAML scalar does for itself.
+//
+// Task metadata is written "@{ ticket: 'value' }", which mermaid reads as YAML
+// and then draws. A closing brace ends the block, and a double quote is refused
+// by the kanban lexer before YAML ever sees the line.
+const metadataUnsafe = `"}`
+
+// escapeLabel returns label ready to be written between the brackets of a card.
+//
+// Each character above is written as the entity form mermaid decodes, found by
+// rendering them one at a time. A "#" that would start an entity is escaped
+// with them, or a label holding "#93;" and a label holding a closing bracket
+// would draw the same card; a "#" anywhere else comes out unchanged.
+func escapeLabel(label string) string {
+	return escapeEntities(label, labelUnsafe)
+}
+
+// escapeMetadata returns value as the single quoted YAML scalar a task's
+// metadata takes.
+//
+// Three escapes meet in one string here and each belongs to a different reader.
+// A backslash and the control characters are written the way YAML's escape
+// takes them. A single quote is doubled, which is what YAML itself does with
+// one inside a single quoted scalar: writing "\'" instead, as this package used
+// to, makes the YAML parser refuse the line and lose the diagram. What is left
+// is the punctuation the kanban lexer takes before YAML sees it, and that is
+// written as a mermaid entity.
+func escapeMetadata(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, "\r", `\r`)
+	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+	escaped = strings.ReplaceAll(escaped, "\t", `\t`)
+	escaped = strings.ReplaceAll(escaped, `'`, `''`)
+	return "'" + escapeEntities(escaped, metadataUnsafe) + "'"
+}
+
+// escapeEntities writes each character in unsafe, and any "#" that would start
+// an entity, as the form mermaid decodes.
+func escapeEntities(text, unsafe string) string {
+	if !strings.ContainsAny(text, unsafe+"#") {
+		return text
+	}
+
+	var b strings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		switch {
+		case strings.IndexByte(unsafe, text[i]) >= 0:
+			b.WriteString(internal.EntityEscape(rune(text[i])))
+		case text[i] == '#' && internal.StartsEntity(text[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(text[i])
+		}
+	}
+	return b.String()
+}

--- a/mermaid/kanban/kanban.go
+++ b/mermaid/kanban/kanban.go
@@ -263,13 +263,13 @@ func (d *Diagram) Task(name string, opts ...TaskOption) *Diagram {
 	line := formatCard(trimmedID, trimmedName)
 	metadata := make([]string, 0, taskMetadataCap)
 	if trimmedTicket != "" {
-		metadata = append(metadata, fmt.Sprintf("ticket: %s", quoteMetadata(trimmedTicket)))
+		metadata = append(metadata, fmt.Sprintf("ticket: %s", escapeMetadata(trimmedTicket)))
 	}
 	if trimmedAssigned != "" {
-		metadata = append(metadata, fmt.Sprintf("assigned: %s", quoteMetadata(trimmedAssigned)))
+		metadata = append(metadata, fmt.Sprintf("assigned: %s", escapeMetadata(trimmedAssigned)))
 	}
 	if normalizedPriority != "" {
-		metadata = append(metadata, fmt.Sprintf("priority: %s", quoteMetadata(normalizedPriority)))
+		metadata = append(metadata, fmt.Sprintf("priority: %s", escapeMetadata(normalizedPriority)))
 	}
 	if len(metadata) > 0 {
 		line += fmt.Sprintf("@{ %s }", strings.Join(metadata, ", "))
@@ -341,9 +341,6 @@ func validateCardLabel(fieldName, value string) (string, error) {
 	if normalized == "" {
 		return "", fmt.Errorf("%s must not be empty", fieldName)
 	}
-	if strings.ContainsAny(normalized, "[]") {
-		return "", fmt.Errorf("%s must not contain '[' or ']'", fieldName)
-	}
 	return normalized, nil
 }
 
@@ -387,9 +384,9 @@ func validateText(fieldName, value string) (string, error) {
 
 func formatCard(id, label string) string {
 	if id == "" {
-		return fmt.Sprintf("[%s]", label)
+		return fmt.Sprintf("[%s]", escapeLabel(label))
 	}
-	return fmt.Sprintf("%s[%s]", id, label)
+	return fmt.Sprintf("%s[%s]", id, escapeLabel(label))
 }
 
 func normalizeBracketed(value string) string {
@@ -402,15 +399,6 @@ func normalizeBracketed(value string) string {
 
 func containsNewline(value string) bool {
 	return strings.ContainsAny(value, "\n\r")
-}
-
-func quoteMetadata(value string) string {
-	escaped := strings.ReplaceAll(value, `\`, `\\`)
-	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
-	escaped = strings.ReplaceAll(escaped, "\r", `\r`)
-	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
-	escaped = strings.ReplaceAll(escaped, "\t", `\t`)
-	return "'" + escaped + "'"
 }
 
 func quoteYAML(value string) string {

--- a/mermaid/kanban/kanban_test.go
+++ b/mermaid/kanban/kanban_test.go
@@ -185,7 +185,7 @@ func TestDiagram_BracketedNamesAndMetadataEscaping(t *testing.T) {
 
 	want := `kanban
     [Todo]
-        [Fix parser]@{ ticket: 'KB-\\123', assigned: 'O\'Reilly' }`
+        [Fix parser]@{ ticket: 'KB-\\123', assigned: 'O''Reilly' }`
 
 	got := strings.ReplaceAll(d.String(), "\r\n", "\n")
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -223,13 +223,6 @@ func TestDiagram_Error(t *testing.T) {
 			want: "kanban",
 		},
 		{
-			name: "column name with bracket char",
-			run: func() *Diagram {
-				return NewDiagram(io.Discard).Column("To[do]")
-			},
-			want: "kanban",
-		},
-		{
 			name: "column id with whitespace",
 			run: func() *Diagram {
 				return NewDiagram(io.Discard).Column("Todo", WithColumnID("to do"))
@@ -248,14 +241,6 @@ func TestDiagram_Error(t *testing.T) {
 			name: "task name with newline",
 			run: func() *Diagram {
 				return NewDiagram(io.Discard).Column("Todo").Task("Define\nscope")
-			},
-			want: `kanban
-    [Todo]`,
-		},
-		{
-			name: "task name with bracket char",
-			run: func() *Diagram {
-				return NewDiagram(io.Discard).Column("Todo").Task("Fix [parser]")
 			},
 			want: `kanban
     [Todo]`,
@@ -447,5 +432,104 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	}
 	if !errors.Is(err, errWrite) {
 		t.Errorf("Build lost the destination error: %v", err)
+	}
+}
+
+// TestCardLabelEscapesWhatEndsIt names the characters this escaping buys in a
+// card. A card is written "id[label]" and mermaid ends the label at a closing
+// bracket, a parenthesis or a closing brace, so a task called "Fix parser (v2)"
+// lost the whole diagram. A bracket used to be rejected outright instead, which
+// is not this library's job: a caller passes data and the builder encodes it.
+func TestCardLabelEscapesWhatEndsIt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(io.Writer) *Diagram
+		want  string
+	}{
+		"parentheses in a column": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Column("Todo (soon)") },
+			want:  "    [Todo #40;soon#41;]",
+		},
+		"a closing bracket in a task": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Column("Todo").Task("Fix parser]")
+			},
+			want: "        [Fix parser#93;]",
+		},
+		"a closing brace in a task": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Column("Todo").Task("a}b")
+			},
+			want: "        [a#125;b]",
+		},
+		"an opening bracket and brace are left alone": {
+			// mermaid takes either inside a label, so escaping them would
+			// change output that already reaches the drawing.
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Column("Todo").Task("a[b{c")
+			},
+			want: "        [a[b{c]",
+		},
+		"a quote needs nothing in a label": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Column("Todo").Task(`say "hi" to O'Reilly`)
+			},
+			want: `        [say "hi" to O'Reilly]`,
+		},
+		"a named entity is escaped": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Column("a#93;b") },
+			want:  "    [a#35;93;b]",
+		},
+		"a plain hash is left alone": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Column("PR #123") },
+			want:  "    [PR #123]",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(io.Discard).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMetadataEscapingMeetsThreeReaders names what a metadata value has to get
+// past. mermaid reads "@{ ticket: 'value' }" as YAML and then draws the result,
+// so a single quote is doubled the way YAML wants it, while the punctuation the
+// kanban lexer takes before YAML ever sees the line is written as a mermaid
+// entity. Writing "\'" for the quote, as this package used to, makes the YAML
+// parser refuse the line and lose the diagram.
+func TestMetadataEscapingMeetsThreeReaders(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value string
+		want  string
+	}{
+		"a single quote is doubled":     {value: "O'Reilly", want: "ticket: 'O''Reilly'"},
+		"a double quote is an entity":   {value: `say "hi"`, want: `ticket: 'say #quot;hi#quot;'`},
+		"a closing brace is an entity":  {value: "a}b", want: "ticket: 'a#125;b'"},
+		"a backslash keeps its escape":  {value: `KB-\123`, want: `ticket: 'KB-\\123'`},
+		"an opening brace is left":      {value: "a{b", want: "ticket: 'a{b'"},
+		"a plain hash is left alone":    {value: "PR #123", want: "ticket: 'PR #123'"},
+		"a named entity gets escaped":   {value: "a#125;b", want: "ticket: 'a#35;125;b'"},
+		"ordinary text is left as text": {value: "KB-1", want: "ticket: 'KB-1'"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := NewDiagram(io.Discard).Column("Todo").Task("t", WithTaskTicket(tt.value)).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `kanban`, and it is the largest of them: three separate defects, each losing the whole diagram.

## 1. A card label ends early

A card is written `id[label]`. mermaid ends the label at a `]`, `(`, `)` or `}` — `Task("Fix parser (v2)")` was enough to leave the reader an error box. All four are now written as the entity form mermaid decodes.

`[` and `{` are deliberately **not** escaped: mermaid takes either inside a label, and escaping them would change output that already reaches the drawing.

## 2. A bracket was rejected rather than encoded

`validateCardLabel` returned an error for `[` or `]`. The issue is explicit that this is not the fix — "a label that mermaid cannot take is not a caller error; the builder's job is to encode it" — so the validation is gone and the escaping above replaces it. Two test cases that pinned the rejection go with it.

## 3. Metadata quoting was broken for the commonest case

`@{ ticket: 'value' }` is read as YAML by mermaid and then drawn, so three escapes meet in one string and each belongs to a different reader:

| character | was | is | why |
|---|---|---|---|
| `'` | `\'` | `''` | `\'` makes the **YAML parser** refuse the line — `O'Reilly` lost the diagram |
| `"` | raw | `#quot;` | the **kanban lexer** takes the line before YAML sees it |
| `}` | raw | `#125;` | ends the metadata block |
| `\`, `\n`, `\r`, `\t` | unchanged | unchanged | YAML's own escapes, and they work |

The golden expectation in `TestDiagram_BracketedNamesAndMetadataEscaping` moves from `'O\'Reilly'` to `'O''Reilly'` — from the form that loses the diagram to the one that draws it.

## Verification

- `go test ./...` passes; `golangci-lint run ./...` reports 0 issues.
- `mermaid/kanban` coverage 97.3%.
- The `kanban` entry in `doc/edgecase/main.go` goes from `#;{<br/>`+emoji+Japanese+`:,*-|%%` to the full probe set, and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kanban rendering for labels and metadata containing quotes, brackets, braces, punctuation, symbols, hashes, backslashes, and Unicode characters.
  * Added reliable escaping for YAML and Mermaid syntax, preventing special characters from breaking diagrams.
  * Kanban column and task names now support bracket characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->