### PR TITLE
fix(mermaid): escape the semicolon that ends a state statement

### DIFF
--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -121,11 +121,10 @@ func supported(diagram string) string {
 		// name, and a parenthesis or a brace in one ends it too once the name
 		// holds anything else.
 		"sequence": `"'#[]` + emoji + japanese + `*-|`,
-		// state: a colon ends the note it is written in. A quote, a hash, a
-		// semicolon, a bracket, a brace or a parenthesis each end a state
-		// description once it holds anything else, so a description is down to
-		// text and the punctuation below.
-		"state": emoji + japanese + `,*-|%%`,
+		// state writes the colon that would end a one line note as the entity
+		// form mermaid decodes, and every other construct here takes the
+		// punctuation as it is.
+		"state": `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
 		// treemap doubles a quote in a name and everything else, a backslash
 		// included, is text inside the quotes, so only a line break is left
 		// out: the hierarchy is indentation, and a name spanning lines would

--- a/doc/edgecase/state.md
+++ b/doc/edgecase/state.md
@@ -4,12 +4,12 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 ---
-title: "title 🎉日本語,*-|%%"
+title: "title \"'#;[](){}🎉日本語:,*-|%%"
 ---
 stateDiagram-v2
-    Draft : before 🎉日本語,*-|%% after
-    Placed : x🎉日本語,*-|%%x
+    Draft : before "'##59;[](){}<br/>🎉日本語:,*-|%% after
+    Placed : x"'##59;[](){}<br/>🎉日本語:,*-|%%x
     Draft --> Placed
-    Placed --> Draft : x🎉日本語,*-|%%x
-    note right of Draft : before 🎉日本語,*-|%% after
+    Placed --> Draft : x"'##59;[](){}<br/>🎉日本語:,*-|%%x
+    note right of Draft : before "'##59;[](){}<br/>🎉日本語#58;,*-|%% after
 ```

--- a/mermaid/state/escape.go
+++ b/mermaid/state/escape.go
@@ -1,0 +1,54 @@
+package state
+
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+const (
+	// statementUnsafe is what a state description or a transition label cannot
+	// carry.
+	//
+	// A semicolon ends the statement it is written in. What follows is then
+	// parsed as a statement of its own, so whether the diagram survives depends
+	// on what happens to come next: "a;b" draws, because "b" reads as a state
+	// id, and "a;b{c" loses the whole diagram because "{" does not read as
+	// anything. A description is prose and cannot be relied on to end in a word.
+	statementUnsafe = ";"
+	// noteUnsafe is what a one line note cannot carry. "note right of s1 : text"
+	// is the one construct here that reads a colon as syntax, and a second one
+	// ends the note.
+	noteUnsafe = ";:"
+)
+
+// escapeStatement returns text ready to be written into a construct that cannot
+// carry the characters in unsafe.
+//
+// Each is written as the entity form mermaid decodes, found by rendering them
+// one at a time. A "#" that would start an entity is escaped with them, or text
+// holding "#59;" and text holding a semicolon would draw the same diagram; a
+// "#" anywhere else is ordinary text and comes out unchanged.
+//
+// The lines of a multi line note need none of this: mermaid reads each as text
+// until "end note" and takes every character probed, colon and semicolon
+// included.
+func escapeStatement(text, unsafe string) string {
+	if !strings.ContainsAny(text, unsafe+"#") {
+		return text
+	}
+
+	var b strings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		switch {
+		case strings.IndexByte(unsafe, text[i]) >= 0:
+			b.WriteString(internal.EntityEscape(rune(text[i])))
+		case text[i] == '#' && internal.StartsEntity(text[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(text[i])
+		}
+	}
+	return b.String()
+}

--- a/mermaid/state/state_diagram.go
+++ b/mermaid/state/state_diagram.go
@@ -83,7 +83,7 @@ func (d *Diagram) State(id, description string) *Diagram {
 	if description == "" {
 		d.body = append(d.body, fmt.Sprintf("    %s", id))
 	} else {
-		d.body = append(d.body, fmt.Sprintf("    %s : %s", id, description))
+		d.body = append(d.body, fmt.Sprintf("    %s : %s", id, escapeStatement(description, statementUnsafe)))
 	}
 	return d
 }
@@ -96,7 +96,7 @@ func (d *Diagram) Transition(from, to string) *Diagram {
 
 // TransitionWithNote adds a transition between states with a note.
 func (d *Diagram) TransitionWithNote(from, to, note string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s --> %s : %s", from, to, note))
+	d.body = append(d.body, fmt.Sprintf("    %s --> %s : %s", from, to, escapeStatement(note, statementUnsafe)))
 	return d
 }
 
@@ -108,7 +108,7 @@ func (d *Diagram) StartTransition(to string) *Diagram {
 
 // StartTransitionWithNote adds a transition from the start state with a note.
 func (d *Diagram) StartTransitionWithNote(to, note string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    [*] --> %s : %s", to, note))
+	d.body = append(d.body, fmt.Sprintf("    [*] --> %s : %s", to, escapeStatement(note, statementUnsafe)))
 	return d
 }
 
@@ -120,19 +120,19 @@ func (d *Diagram) EndTransition(from string) *Diagram {
 
 // EndTransitionWithNote adds a transition to the end state with a note.
 func (d *Diagram) EndTransitionWithNote(from, note string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s --> [*] : %s", from, note))
+	d.body = append(d.body, fmt.Sprintf("    %s --> [*] : %s", from, escapeStatement(note, statementUnsafe)))
 	return d
 }
 
 // NoteLeft adds a note on the left side of a state.
 func (d *Diagram) NoteLeft(state, note string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    note left of %s : %s", state, note))
+	d.body = append(d.body, fmt.Sprintf("    note left of %s : %s", state, escapeStatement(note, noteUnsafe)))
 	return d
 }
 
 // NoteRight adds a note on the right side of a state.
 func (d *Diagram) NoteRight(state, note string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    note right of %s : %s", state, note))
+	d.body = append(d.body, fmt.Sprintf("    note right of %s : %s", state, escapeStatement(note, noteUnsafe)))
 	return d
 }
 
@@ -176,7 +176,7 @@ func (b *CompositeStateBuilder) State(id, description string) *CompositeStateBui
 	if description == "" {
 		b.body = append(b.body, fmt.Sprintf("        %s", id))
 	} else {
-		b.body = append(b.body, fmt.Sprintf("        %s : %s", id, description))
+		b.body = append(b.body, fmt.Sprintf("        %s : %s", id, escapeStatement(description, statementUnsafe)))
 	}
 	return b
 }
@@ -189,7 +189,7 @@ func (b *CompositeStateBuilder) Transition(from, to string) *CompositeStateBuild
 
 // TransitionWithNote adds a transition with a note in the composite state.
 func (b *CompositeStateBuilder) TransitionWithNote(from, to, note string) *CompositeStateBuilder {
-	b.body = append(b.body, fmt.Sprintf("        %s --> %s : %s", from, to, note))
+	b.body = append(b.body, fmt.Sprintf("        %s --> %s : %s", from, to, escapeStatement(note, statementUnsafe)))
 	return b
 }
 

--- a/mermaid/state/state_diagram_test.go
+++ b/mermaid/state/state_diagram_test.go
@@ -589,3 +589,80 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestStatementTextEscapesTheSemicolonThatEndsIt names the character this
+// escaping buys. A semicolon in a state description or a transition label ends
+// the statement, and what follows is parsed as one of its own: "a;b" happens to
+// draw because "b" reads as a state id, while "a;b{c" loses the whole diagram.
+// A description is prose and cannot be relied on to end in a word, so the
+// semicolon is escaped whatever follows it.
+func TestStatementTextEscapesTheSemicolonThatEndsIt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(io.Writer) *Diagram
+		want  string
+	}{
+		"a semicolon in a description": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).State("s1", "queued; retrying") },
+			want:  "    s1 : queued#59; retrying",
+		},
+		"a semicolon in a transition label": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).TransitionWithNote("s1", "s2", "a;b")
+			},
+			want: "    s1 --> s2 : a#59;b",
+		},
+		"a semicolon in a start transition": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).StartTransitionWithNote("s1", "a;b") },
+			want:  "    [*] --> s1 : a#59;b",
+		},
+		"a semicolon in an end transition": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).EndTransitionWithNote("s1", "a;b") },
+			want:  "    s1 --> [*] : a#59;b",
+		},
+		"a colon in a description is left alone": {
+			// Only the one line note reads a colon as syntax.
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).State("s1", "retry: three times") },
+			want:  "    s1 : retry: three times",
+		},
+		"a colon and a semicolon in a one line note": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).State("s1", "d").NoteRight("s1", "retry: three; then stop")
+			},
+			want: "    note right of s1 : retry#58; three#59; then stop",
+		},
+		"a named entity is escaped": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).State("s1", "a#59;b") },
+			want:  "    s1 : a#35;59#59;b",
+		},
+		"a plain hash is left alone": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).State("s1", "PR #123") },
+			want:  "    s1 : PR #123",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(io.Discard).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMultiLineNoteKeepsItsPunctuation pins the other half: mermaid reads each
+// line of a multi line note as text until "end note" and takes every character
+// probed, so escaping there would change output that is correct today.
+func TestMultiLineNoteKeepsItsPunctuation(t *testing.T) {
+	t.Parallel()
+
+	got := NewDiagram(io.Discard).State("s1", "d").NoteRightMultiLine("s1", "retry: three; then stop").String()
+
+	if want := "        retry: three; then stop"; !strings.Contains(got, want) {
+		t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, want)
+	}
+}


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `state`.

## What the measurement said, and what is actually true

The issue lists `state` as losing the diagram on `"` `#` `;` `[` `]` `(` `)` `{` `}` in a description, plus `:` in a note — one of the worst entries in the table. Re-measured against the current renderer, one character at a time, **only two of those are real**:

- `;` ends the statement, in a description and in a transition label.
- `:` ends a one-line note, as recorded.

Everything else — quotes, hashes, brackets, braces, parentheses — reaches the drawing intact. The old entry predates this package quoting anything and had gone stale.

## Why the semicolon is escaped even though `a;b` renders

Because whether it renders is luck. The `;` ends the statement and mermaid parses what follows as a new one:

- `s1 : queued;retrying` draws — `retrying` happens to read as a state id.
- `s1 : queued;{retrying}` loses the whole diagram — `{` reads as nothing.

A description is prose. It cannot be relied on to end in a word, so the semicolon is escaped whatever follows it. That is the one place in this pull request where output changes for input that renders today, and it is deliberate.

## What is deliberately not touched

- A `:` in a **description** or a **transition label** — only the one-line note reads it as syntax.
- Every character in the lines of a **multi-line note** — mermaid reads those as text until `end note`.

Both are pinned by tests so a later sweep does not escape them.

## Verification

- `go test ./...` passes with **no golden file changed**; `golangci-lint run ./...` reports 0 issues.
- `mermaid/state` coverage 97.8%.
- The `state` entry in `doc/edgecase/main.go` goes from emoji + Japanese + `,*-|%%` to the full probe set, and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.