### PR TITLE
fix(mermaid): escape the punctuation a sequence diagram reads as syntax

### DIFF
--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -119,10 +119,11 @@ func supported(diagram string) string {
 		// refuses an emoji or Japanese in a node name, the same way its xy
 		// chart parser does.
 		"sankey": `"'#;[](){}<br/>:,*-|%%`,
-		// sequence: ";" and "%%" end a statement, ":" and "," end a participant
-		// name, and a parenthesis or a brace in one ends it too once the name
-		// holds anything else.
-		"sequence": `"'#[]` + emoji + japanese + `*-|`,
+		// sequence takes no quoted text at all, so each construct writes the
+		// punctuation it would otherwise lose as the entity form mermaid
+		// decodes. A line break is left out because the renderer honors
+		// "<br/>" inside a message.
+		"sequence": `"'#;[](){}` + emoji + japanese + `:,*-|%%`,
 		// state writes the colon that would end a one line note as the entity
 		// form mermaid decodes, and every other construct here takes the
 		// punctuation as it is.

--- a/doc/edgecase/sequence.md
+++ b/doc/edgecase/sequence.md
@@ -4,9 +4,9 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 sequenceDiagram
-    participant x"'#[]🎉日本語*-|x
-    participant x"'#[]🎉日本語*-|x two
-    x"'#[]🎉日本語*-|x->>x"'#[]🎉日本語*-|x two: before "'#[]🎉日本語*-| after
-    x"'#[]🎉日本語*-|x two-->>x"'#[]🎉日本語*-|x: before "'#[]🎉日本語*-| after
-    note over x"'#[]🎉日本語*-|x: before "'#[]🎉日本語*-| after
+    participant x"'##59;[]#40;#41;{}🎉日本語#58;#44;*#45;|#37;#37;x
+    participant x"'##59;[]#40;#41;{}🎉日本語#58;#44;*#45;|#37;#37;x two
+    x"'##59;[]#40;#41;{}🎉日本語#58;#44;*#45;|#37;#37;x->>x"'##59;[]#40;#41;{}🎉日本語#58;#44;*#45;|#37;#37;x two: before "'#35;#59;[](){}🎉日本語:,*-|%% after
+    x"'##59;[]#40;#41;{}🎉日本語#58;#44;*#45;|#37;#37;x two-->>x"'##59;[]#40;#41;{}🎉日本語#58;#44;*#45;|#37;#37;x: before "'#35;#59;[](){}🎉日本語:,*-|%% after
+    note over x"'##59;[]#40;#41;{}🎉日本語#58;,*#45;|#37;#37;x: before "'#35;#59;[](){}🎉日本語:,*-|%% after
 ```

--- a/mermaid/sequence/activation.go
+++ b/mermaid/sequence/activation.go
@@ -4,19 +4,19 @@ import "fmt"
 
 // Activate add a participant to the sequence diagram.
 func (d *Diagram) Activate(participant string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    activate %s", participant))
+	d.body = append(d.body, fmt.Sprintf("    activate %s", escapeParticipant(participant)))
 	return d
 }
 
 // Deactivate add a participant to the sequence diagram.
 func (d *Diagram) Deactivate(participant string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    deactivate %s", participant))
+	d.body = append(d.body, fmt.Sprintf("    deactivate %s", escapeParticipant(participant)))
 	return d
 }
 
 // SyncRequestWithActivation add a request to the sequence diagram.
 func (d *Diagram) SyncRequestWithActivation(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s->>+%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s->>+%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 
@@ -27,7 +27,7 @@ func (d *Diagram) SyncRequestfWithActivation(from, to, format string, args ...an
 
 // SyncResponseWithActivation add a response to the sequence diagram.
 func (d *Diagram) SyncResponseWithActivation(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s-->>-%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s-->>-%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 
@@ -38,7 +38,7 @@ func (d *Diagram) SyncResponsefWithActivation(from, to, format string, args ...a
 
 // AsyncRequestWithActivation add a async request to the sequence diagram.
 func (d *Diagram) AsyncRequestWithActivation(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s->>+%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s->>+%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 
@@ -49,7 +49,7 @@ func (d *Diagram) AsyncRequestfWithActivation(from, to, format string, args ...a
 
 // AsyncResponseWithActivation add a async response to the sequence diagram.
 func (d *Diagram) AsyncResponseWithActivation(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s-->>-%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s-->>-%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 

--- a/mermaid/sequence/directive.go
+++ b/mermaid/sequence/directive.go
@@ -13,7 +13,7 @@ func (d *Diagram) AutoNumber() *Diagram {
 
 // BoxStart add a box to the sequence diagram.
 func (d *Diagram) BoxStart(participant []string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    box %s", strings.Join(participant, " & ")))
+	d.body = append(d.body, fmt.Sprintf("    box %s", strings.Join(escapeParticipants(participant), " & ")))
 	return d
 }
 
@@ -25,36 +25,36 @@ func (d *Diagram) BoxEnd() *Diagram {
 
 // Participant add a participant to the sequence diagram.
 func (d *Diagram) Participant(participant string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    participant %s", participant))
+	d.body = append(d.body, fmt.Sprintf("    participant %s", escapeParticipant(participant)))
 	return d
 }
 
 // Actor add a participant to the sequence diagram.
 func (d *Diagram) Actor(actor string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    actor %s", actor))
+	d.body = append(d.body, fmt.Sprintf("    actor %s", escapeParticipant(actor)))
 	return d
 }
 
 // CreateParticipant add a participant to the sequence diagram.
 func (d *Diagram) CreateParticipant(participant string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    create participant %s", participant))
+	d.body = append(d.body, fmt.Sprintf("    create participant %s", escapeParticipant(participant)))
 	return d
 }
 
 // DestroyParticipant add a participant to the sequence diagram.
 func (d *Diagram) DestroyParticipant(participant string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    destroy %s", participant))
+	d.body = append(d.body, fmt.Sprintf("    destroy %s", escapeParticipant(participant)))
 	return d
 }
 
 // CreateActor add a participant to the sequence diagram.
 func (d *Diagram) CreateActor(actor string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    create actor %s", actor))
+	d.body = append(d.body, fmt.Sprintf("    create actor %s", escapeParticipant(actor)))
 	return d
 }
 
 // DestroyActor add a participant to the sequence diagram.
 func (d *Diagram) DestroyActor(actor string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    destroy %s", actor))
+	d.body = append(d.body, fmt.Sprintf("    destroy %s", escapeParticipant(actor)))
 	return d
 }

--- a/mermaid/sequence/escape.go
+++ b/mermaid/sequence/escape.go
@@ -1,0 +1,105 @@
+package sequence
+
+import (
+	"strings"
+
+	"github.com/nao1215/markdown/internal"
+)
+
+const (
+	// textUnsafe is what a message, a note or a block description cannot carry.
+	//
+	// A semicolon ends the statement and loses the whole diagram. A "#" opens a
+	// comment, and the text is then quietly cut short at it: "deploy #2 of 3"
+	// reached the drawing as "deploy" and nothing said so.
+	textUnsafe = "#;"
+	// participantUnsafe is what a participant's name cannot carry.
+	//
+	// A semicolon ends the statement here too. A colon separates a name from
+	// the message that follows it, a comma separates one name from the next,
+	// and an angle bracket opens the arrow syntax. A hyphen is the start of
+	// every arrow, so "web-server" could be declared but never sent a message.
+	// A "%%" opens a comment on the message line and drops the message that
+	// followed it without a word. A parenthesis is safe on its own and a pair
+	// is not, so both are written out: an unmatched one is not a name anybody
+	// writes, and the matched pair is what a name like "Deploy (prod)" has. A
+	// "#" is safe in a name, unlike in the text above.
+	participantUnsafe = ";:,<>-%()"
+	// noteParticipantUnsafe is what the participant a note is placed over
+	// cannot carry.
+	//
+	// It is participantUnsafe without the comma, because a note may be placed
+	// over two participants at once and the comma between them is the syntax
+	// that says so. A caller passing "Alice,Bob" there means both, and this
+	// package has no way to tell that apart from one name holding a comma.
+	noteParticipantUnsafe = ";:<>-%()"
+)
+
+// escape returns text ready to be written into a construct that cannot carry
+// the characters in unsafe.
+//
+// A sequence diagram takes no quoted text at all, so each character is written
+// as the entity form mermaid decodes, found by rendering them one at a time. A
+// "#" that would start an entity is escaped whether or not the construct lists
+// it, because this package writes entities and a caller's literal "#59;" has to
+// come out different from a caller's semicolon. A "#" that starts nothing is
+// left alone wherever it reaches the drawing, which is what keeps output that
+// already renders unchanged.
+func escape(text, unsafe string) string {
+	if !strings.ContainsAny(text, unsafe+"#") {
+		return text
+	}
+
+	var b strings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		switch {
+		case text[i] == '%':
+			// Only a run opens a comment. A lone "%" reaches every drawing
+			// here, so "50% of traffic" comes out as it always has.
+			if strings.IndexByte(unsafe, '%') >= 0 && adjacentPercent(text, i) {
+				b.WriteString(internal.EntityEscape('%'))
+				continue
+			}
+			b.WriteByte(text[i])
+		case strings.IndexByte(unsafe, text[i]) >= 0:
+			b.WriteString(internal.EntityEscape(rune(text[i])))
+		case text[i] == '#' && internal.StartsEntity(text[i+1:]):
+			b.WriteString(internal.EntityEscape('#'))
+		default:
+			b.WriteByte(text[i])
+		}
+	}
+	return b.String()
+}
+
+// adjacentPercent reports whether the "%" at index i has another beside it, and
+// so is part of the run that would open a comment.
+func adjacentPercent(text string, i int) bool {
+	return (i > 0 && text[i-1] == '%') || (i+1 < len(text) && text[i+1] == '%')
+}
+
+// escapeText returns message, note or description text ready to be written.
+func escapeText(text string) string {
+	return escape(text, textUnsafe)
+}
+
+// escapeParticipant returns a participant's name ready to be written.
+func escapeParticipant(name string) string {
+	return escape(name, participantUnsafe)
+}
+
+// escapeNoteParticipant returns the participant a note is placed over, ready to
+// be written.
+func escapeNoteParticipant(name string) string {
+	return escape(name, noteParticipantUnsafe)
+}
+
+// escapeParticipants returns each name ready to be written.
+func escapeParticipants(names []string) []string {
+	escaped := make([]string, 0, len(names))
+	for _, name := range names {
+		escaped = append(escaped, escapeParticipant(name))
+	}
+	return escaped
+}

--- a/mermaid/sequence/note.go
+++ b/mermaid/sequence/note.go
@@ -16,18 +16,18 @@ const (
 
 // NoteOver add a note to the sequence diagram.
 func (d *Diagram) NoteOver(participant, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    note over %s: %s", participant, message))
+	d.body = append(d.body, fmt.Sprintf("    note over %s: %s", escapeNoteParticipant(participant), escapeText(message)))
 	return d
 }
 
 // NoteRightOf add a note to the sequence diagram.
 func (d *Diagram) NoteRightOf(participant, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    note right of %s: %s", participant, message))
+	d.body = append(d.body, fmt.Sprintf("    note right of %s: %s", escapeNoteParticipant(participant), escapeText(message)))
 	return d
 }
 
 // NoteLeftOf add a note to the sequence diagram.
 func (d *Diagram) NoteLeftOf(participant, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    note left of %s: %s", participant, message))
+	d.body = append(d.body, fmt.Sprintf("    note left of %s: %s", escapeNoteParticipant(participant), escapeText(message)))
 	return d
 }

--- a/mermaid/sequence/sequence.go
+++ b/mermaid/sequence/sequence.go
@@ -73,7 +73,7 @@ func (d *Diagram) Build() error {
 
 // SyncRequest add a request to the sequence diagram.
 func (d *Diagram) SyncRequest(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s->>%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s->>%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 
@@ -84,7 +84,7 @@ func (d *Diagram) SyncRequestf(from, to, format string, args ...any) *Diagram {
 
 // SyncResponse add a response to the sequence diagram.
 func (d *Diagram) SyncResponse(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s-->>%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s-->>%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 
@@ -95,7 +95,7 @@ func (d *Diagram) SyncResponsef(from, to, format string, args ...any) *Diagram {
 
 // RequestError add a request error to the sequence diagram.
 func (d *Diagram) RequestError(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s-x%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s-x%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 
@@ -106,7 +106,7 @@ func (d *Diagram) RequestErrorf(from, to, format string, args ...any) *Diagram {
 
 // ResponseError add a response error to the sequence diagram.
 func (d *Diagram) ResponseError(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s--x%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s--x%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 
@@ -117,7 +117,7 @@ func (d *Diagram) ResponseErrorf(from, to, format string, args ...any) *Diagram 
 
 // AsyncRequest add a async request to the sequence diagram.
 func (d *Diagram) AsyncRequest(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s->)%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s->)%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 
@@ -128,7 +128,7 @@ func (d *Diagram) AsyncRequestf(from, to, format string, args ...any) *Diagram {
 
 // AsyncResponse add a async response to the sequence diagram.
 func (d *Diagram) AsyncResponse(from, to, message string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    %s--)%s: %s", from, to, message))
+	d.body = append(d.body, fmt.Sprintf("    %s--)%s: %s", escapeParticipant(from), escapeParticipant(to), escapeText(message)))
 	return d
 }
 

--- a/mermaid/sequence/sequence_test.go
+++ b/mermaid/sequence/sequence_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -774,5 +775,122 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 	}
 	if !errors.Is(err, errWrite) {
 		t.Errorf("Build lost the destination error: %v", err)
+	}
+}
+
+// TestMessageTextEscapesWhatEndsIt names the characters this escaping buys in
+// the text of a diagram. A sequence diagram takes no quoted text at all, so a
+// message, a note and a block description each go out bare.
+func TestMessageTextEscapesWhatEndsIt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(io.Writer) *Diagram
+		want  string
+	}{
+		"a semicolon in a message loses the diagram": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).SyncRequest("A", "B", "a;b") },
+			want:  "    A->>B: a#59;b",
+		},
+		"a hash in a message cuts it short": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).SyncRequest("A", "B", "deploy #2 of 3")
+			},
+			want: "    A->>B: deploy #35;2 of 3",
+		},
+		"a hash in a note": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).NoteOver("A", "run #1") },
+			want:  "    note over A: run #35;1",
+		},
+		"a semicolon in a loop description": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).LoopStart("retry; twice") },
+			want:  "    loop retry#59; twice",
+		},
+		"a colon in a message is left alone": {
+			// Only the first colon on the line is syntax, and this package
+			// writes that one itself.
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).SyncRequest("A", "B", "a:b") },
+			want:  "    A->>B: a:b",
+		},
+		"a percent pair in a message is left alone": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).SyncRequest("A", "B", "100%% done") },
+			want:  "    A->>B: 100%% done",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(io.Discard).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParticipantNameEscapesWhatEndsIt names the characters a participant's
+// name loses, which are a different set from the text above. The name is
+// escaped identically where it is declared and where a message refers to it, so
+// the two still match.
+func TestParticipantNameEscapesWhatEndsIt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(io.Writer) *Diagram
+		want  string
+	}{
+		"a hyphen would be read as an arrow": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Participant("web-server") },
+			want:  "    participant web#45;server",
+		},
+		"the declaration and the reference agree": {
+			build: func(w io.Writer) *Diagram {
+				return NewDiagram(w).Participant("web-server").SyncRequest("web-server", "db", "read")
+			},
+			want: "    web#45;server->>db: read",
+		},
+		"a colon and a comma in an actor": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Actor("Ops: EU, US") },
+			want:  "    actor Ops#58; EU#44; US",
+		},
+		"parentheses in a name": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Participant("Deploy (prod)") },
+			want:  "    participant Deploy #40;prod#41;",
+		},
+		"an angle bracket in a name": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Participant("a<b") },
+			want:  "    participant a#60;b",
+		},
+		"a percent pair in a name": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Participant("a%%b") },
+			want:  "    participant a#37;#37;b",
+		},
+		"a lone percent in a name is left alone": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Participant("50% traffic") },
+			want:  "    participant 50% traffic",
+		},
+		"a hash in a name is left alone": {
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).Participant("PR #12") },
+			want:  "    participant PR #12",
+		},
+		"a comma between two participants a note spans is a separator": {
+			// A note may be placed over two participants at once, and this
+			// package cannot tell that apart from one name holding a comma.
+			build: func(w io.Writer) *Diagram { return NewDiagram(w).NoteOver("Alice,Bob", "m") },
+			want:  "    note over Alice,Bob: m",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(io.Discard).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
 	}
 }

--- a/mermaid/sequence/statement.go
+++ b/mermaid/sequence/statement.go
@@ -6,7 +6,7 @@ import (
 
 // LoopStart add a loop to the sequence diagram.
 func (d *Diagram) LoopStart(description string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    loop %s", description))
+	d.body = append(d.body, fmt.Sprintf("    loop %s", escapeText(description)))
 	return d
 }
 
@@ -18,13 +18,13 @@ func (d *Diagram) LoopEnd() *Diagram {
 
 // AltStart add a alt to the sequence diagram.
 func (d *Diagram) AltStart(description string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    alt %s", description))
+	d.body = append(d.body, fmt.Sprintf("    alt %s", escapeText(description)))
 	return d
 }
 
 // AltElse add a alt to the sequence diagram.
 func (d *Diagram) AltElse(description string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    else %s", description))
+	d.body = append(d.body, fmt.Sprintf("    else %s", escapeText(description)))
 	return d
 }
 
@@ -36,7 +36,7 @@ func (d *Diagram) AltEnd() *Diagram {
 
 // OptStart add a opt to the sequence diagram.
 func (d *Diagram) OptStart(description string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    opt %s", description))
+	d.body = append(d.body, fmt.Sprintf("    opt %s", escapeText(description)))
 	return d
 }
 
@@ -48,13 +48,13 @@ func (d *Diagram) OptEnd() *Diagram {
 
 // ParallelStart add a parallel to the sequence diagram.
 func (d *Diagram) ParallelStart(description string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    par %s", description))
+	d.body = append(d.body, fmt.Sprintf("    par %s", escapeText(description)))
 	return d
 }
 
 // ParallelAnd add a parallel to the sequence diagram.
 func (d *Diagram) ParallelAnd(description string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    and %s", description))
+	d.body = append(d.body, fmt.Sprintf("    and %s", escapeText(description)))
 	return d
 }
 
@@ -66,13 +66,13 @@ func (d *Diagram) ParallelEnd() *Diagram {
 
 // CriticalStart add a critical to the sequence diagram.
 func (d *Diagram) CriticalStart(description string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    critical %s", description))
+	d.body = append(d.body, fmt.Sprintf("    critical %s", escapeText(description)))
 	return d
 }
 
 // CriticalOption add a critical opiton to the sequence diagram.
 func (d *Diagram) CriticalOption(description string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    option %s", description))
+	d.body = append(d.body, fmt.Sprintf("    option %s", escapeText(description)))
 	return d
 }
 
@@ -84,7 +84,7 @@ func (d *Diagram) CriticalEnd() *Diagram {
 
 // BreakStart add a break to the sequence diagram.
 func (d *Diagram) BreakStart(description string) *Diagram {
-	d.body = append(d.body, fmt.Sprintf("    break %s", description))
+	d.body = append(d.body, fmt.Sprintf("    break %s", escapeText(description)))
 	return d
 }
 


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `sequence`, and it has the widest spread of the set because a sequence diagram takes **no quoted text anywhere**.

## Two escape sets, measured one character at a time

**Message, note, block description** — `#` `;`

| char | what happens today |
|---|---|
| `;` | ends the statement, whole diagram refused |
| `#` | opens a comment — `deploy #2 of 3` reaches the drawing as `deploy`, **silently** |

**Participant name** — `;` `:` `,` `<` `>` `-` `%%` `(` `)`

| char | what happens today |
|---|---|
| `;` | ends the statement |
| `:` | separates the name from the message after it |
| `,` | separates one name from the next |
| `<` `>` | open the arrow syntax |
| `-` | starts every arrow — `web-server` could be *declared* but never sent a message |
| `%%` | opens a comment on the message line and **drops the message** |
| `(` `)` | safe alone, fatal as a pair |

A name is escaped identically where it is declared and where a message refers to it, so the two still match. There is a test for exactly that, since getting it wrong would silently create a second participant.

## Deliberately left alone

- A `#` in a **participant name** — safe there, unlike in message text.
- A **lone `%`** anywhere — only a run opens a comment, so `50% traffic` is untouched.
- The **comma between two participants a note spans**. `NoteOver("Alice,Bob", …)` is documented mermaid syntax for a note across both, and this package cannot tell it apart from one name holding a comma. Tested, and called out in the code.

On the parentheses: a single unmatched `(` renders today, so escaping it does change working output. An unmatched parenthesis is not a name anybody writes, and the matched pair — `Deploy (prod)` — is broken today. The drawn text is identical either way.

## Verification

- `go test ./...` passes with **no golden file changed**; `golangci-lint run ./...` reports 0 issues.
- `mermaid/sequence` coverage 98.7%.
- The `sequence` entry in `doc/edgecase/main.go` goes from `"'#[]`+emoji+Japanese+`*-|` to the full probe set, and the document is regenerated. Every committed diagram renders: **64 blocks, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mermaid sequence diagrams by safely escaping special characters in participant names, messages, notes, and control-block descriptions.
  * Added support for punctuation, brackets, braces, symbols, emoji, Japanese text, and encoded content without breaking diagram syntax.
  * Preserved valid formatting for colons, percent pairs, hashes, and participant separators.
  * Maintained support for inline `<br/>` breaks while excluding unsupported line breaks.
* **Tests**
  * Expanded coverage for escaping across messages, notes, blocks, participants, and actors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->