### PR TITLE
docs(mermaid): state what an architecture diagram label can hold

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -63,6 +63,7 @@ Raising the `go` directive is a minor release, not a major one, because it does 
 
 These are contracts rather than accidents, and are covered by tests:
 
+- Mermaid diagram labels are escaped by the builder, so text from a database or a command's output can be handed to one without the caller quoting it. The one exception is `mermaid/arch`: mermaid's `architecture-beta` grammar accepts only `[A-Za-z0-9_ ]` in a group or service title, refuses its own `#name;` entity escape there as well, and so leaves nothing to encode to. A title outside that set makes mermaid refuse the whole diagram. The package documents this, and the limit lifts when mermaid's beta grammar does.
 - Text handed to a builder is expected to be valid UTF-8. A mermaid diagram title that is not valid UTF-8 still produces a diagram and still produces parseable YAML front matter, but each byte outside a valid UTF-8 sequence is read back as the code point of that byte: a title holding the single byte `0xC9` is written as `"\xc9"` and reads as `É`. YAML is defined over Unicode, so such a title has no faithful representation in it; the diagram is kept rather than the exact bytes.
 - A builder records the errors it encounters while the chain runs and returns them from `Error` and from `Build`. Nothing in the chain panics on bad input, and no call has to be checked individually.
 - `Build` with a nil writer returns an error rather than panicking.

--- a/doc/edgecase/architecture.md
+++ b/doc/edgecase/architecture.md
@@ -4,8 +4,8 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 
 ```mermaid
 architecture-beta
-    group cloudgroup(cloud)[plainlabel]
-    service api(server)[plainlabel]
-    service db(database)[plainlabel] in cloudgroup
+    group cloudgroup(cloud)[plain_label 1]
+    service api(server)[plain_label 1]
+    service db(database)[plain_label 1] in cloudgroup
     api:R >-- L:db
 ```

--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -65,10 +65,13 @@ const (
 // what keeps this file honest: the labels only ever get harder.
 func supported(diagram string) string {
 	return map[string]string{
-		// architecture writes service and group labels between square brackets
-		// with no quoting at all, and mermaid's architecture-beta grammar takes
-		// only word characters there. Every character probed fails, including a
-		// plain emoji and Japanese text.
+		// architecture writes service and group labels between square brackets,
+		// and mermaid's architecture-beta grammar accepts only [A-Za-z0-9_ ]
+		// there. Every character probed fails, including a plain emoji and
+		// Japanese text, and so does the "#name;" entity form: this lexer
+		// refuses the "#" before anything gets a chance to decode it. There is
+		// nothing to escape to, which is why this entry stays empty rather than
+		// waiting on a fix. SPEC.md records the limit.
 		"architecture": "",
 		"block":        `"'#;[](){}<br/>` + emoji + japanese + `:,*-|%%`,
 		// c4 escapes a quote and a "#" in a label as the entity form mermaid
@@ -174,8 +177,10 @@ func shortLabel(diagram string) string {
 	if p := punctuation(diagram); p != "" {
 		return "x" + p + "x"
 	}
-	// architecture takes no punctuation at all, and no space either.
-	return "plainlabel"
+	// architecture takes no punctuation at all. What it does take is the rest
+	// of [A-Za-z0-9_ ], so the label below covers that whole set: if mermaid's
+	// beta grammar narrows further, this is what fails.
+	return "plain_label 1"
 }
 
 // title is the diagram title. Some types write it into YAML front matter and

--- a/mermaid/arch/architecture.go
+++ b/mermaid/arch/architecture.go
@@ -2,6 +2,23 @@
 // The building blocks of an architecture are groups, services, edges, and junctions.
 // The arch package incorporates beta features of Mermaid, so the specifications are subject to significant changes.
 //
+// # Labels take letters, digits, underscores and spaces, and nothing else
+//
+// A group title and a service title are written between square brackets, and
+// mermaid's architecture-beta grammar accepts only [A-Za-z0-9_ ] there. Every
+// other character makes it refuse the whole diagram, so the reader gets an error
+// box instead of a picture. That includes a quotation mark, an apostrophe, a
+// hyphen, a full stop, a comma, a colon, an emoji and any non-ASCII text: a
+// service titled "Order-Service" or "注文サービス" does not draw.
+//
+// Unlike every other diagram type in this library, there is nothing to escape
+// to. The "#name;" entity form mermaid decodes elsewhere is refused by this
+// lexer before any decoding happens, so "#quot;" fails exactly as a quotation
+// mark does. This package therefore passes a title through as it was given
+// rather than mangling it into something that renders but says something else,
+// and the limit is recorded in SPEC.md. It is a limit of mermaid's beta
+// grammar, and it will lift when that grammar does.
+//
 // Errors are recorded rather than returned from every call: the chain runs to
 // the end and the error surfaces from Build. A nil writer and a writer that
 // refuses the diagram are both reported rather than causing a panic, and

--- a/mermaid/arch/architecture_test.go
+++ b/mermaid/arch/architecture_test.go
@@ -321,3 +321,36 @@ func TestBuildReportsWriteFailure(t *testing.T) {
 		t.Errorf("Build lost the destination error: %v", err)
 	}
 }
+
+// TestTitleIsPassedThroughUnchanged pins the decision recorded in SPEC.md and
+// in this package's documentation: mermaid's architecture-beta grammar accepts
+// only [A-Za-z0-9_ ] in a title and refuses even its own "#name;" escape there,
+// so there is nothing to encode to.
+//
+// A title outside that set is passed through as it was given rather than
+// mangled into something that renders but says something else, and rather than
+// rejected, because a label mermaid cannot take is not a caller error. What
+// this test guards is that no later sweep quietly starts escaping here: the
+// escape would not work, and the output would change for nothing.
+func TestTitleIsPassedThroughUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"the set mermaid accepts": "plain_label 1",
+		"a quotation mark":        `the "core"`,
+		"a hyphen":                "Order-Service",
+		"Japanese":                "注文サービス",
+		"an entity escape":        "a#quot;b",
+	}
+
+	for name, title := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := NewArchitecture(io.Discard).Service("api", IconServer, title).String()
+			if want := "    service api(server)[" + title + "]"; !strings.Contains(got, want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #146 — one subpackage per pull request. This is `arch`, the entry the issue anticipated would have no fix: *"mermaid marks architecture diagrams as beta and its grammar takes only word characters in a label, so there may be nothing to escape to."*

That is exactly what the measurement says.

## Measured

A group or service title goes between square brackets, and `architecture-beta` accepts only `[A-Za-z0-9_ ]` there. Everything else — `"` `'` `-` `.` `,` `:` `;` `#` `%` `*` `|` `(` `)` `[` `]`, emoji, any non-ASCII — makes mermaid refuse the whole diagram. `Order-Service` does not draw. Neither does `注文サービス`.

And crucially: **the entity escape does not work either.** `a#quot;b` fails exactly as `a"b` does, because this lexer refuses the `#` before anything decodes it. The tool every other subpackage in this issue was fixed with is unavailable here.

## So this is documented, not fixed

Per the issue's hard constraint — *"where mermaid genuinely has no representation, say so in SPEC.md and narrow the claim rather than pretending"*:

- `mermaid/arch`'s package doc gains a section saying what a title can hold, what happens when it does not, and why there is nothing to escape to.
- `SPEC.md` records it as the one exception to "the builder escapes your text for you".
- `doc/edgecase/main.go` keeps the empty entry but now explains *why* it is empty rather than reading as unfinished work, and the architecture edge-case label widens from `plainlabel` to `plain_label 1` so the document exercises the **whole** accepted set. If the beta grammar narrows, the render job fails.
- A test pins the pass-through, so a later sweep does not start writing an escape here that would not work and would change output for nothing.

The title is **not** rejected. A label mermaid cannot take is not a caller error, and the limit lifts when the beta grammar does.

## Verification

- `go test ./...` passes with no golden file changed; `golangci-lint run ./...` reports 0 issues.
- Every committed diagram renders: **64 blocks, 0 failed**.