### PR TITLE
docs(mermaid): give every subpackage an example for every symbol

### DIFF
--- a/contract_test.go
+++ b/contract_test.go
@@ -1624,11 +1624,11 @@ func TestReadmeShowsWhatTheGeneratorsProduce(t *testing.T) {
 func TestEveryExportedSymbolHasAnExample(t *testing.T) {
 	t.Parallel()
 
-	// The mermaid subpackages are not in this list yet. Each has an
-	// examples_test.go covering its builder, and filling the gaps in all
-	// twenty one is its own piece of work; this list grows to "mermaid/*" when
-	// that lands.
-	packages := []string{"."}
+	packages, err := filepath.Glob("mermaid/*")
+	if err != nil {
+		t.Fatalf("list the mermaid subpackages: %v", err)
+	}
+	packages = append(packages, ".")
 
 	for _, dir := range packages {
 		t.Run(dir, func(t *testing.T) {

--- a/mermaid/arch/examples_test.go
+++ b/mermaid/arch/examples_test.go
@@ -3,6 +3,7 @@
 package arch_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -115,4 +116,305 @@ func ExampleArchitecture() {
 	//     top_gateway:B -- T:junctionRight
 	//     bottom_gateway:T -- B:junctionRight
 	// ```
+}
+
+// ExampleNewArchitecture shows the shape every architecture diagram has: a
+// writer, a chain of calls, and Build.
+//
+// A title here takes only letters, digits, underscores and spaces. mermaid's
+// architecture-beta grammar accepts nothing else and refuses the whole diagram
+// when it finds it, and there is no escape to reach for; the package
+// documentation says so at more length.
+func ExampleNewArchitecture() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Service("api", arch.IconServer, "API").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     service api(server)[API]
+}
+
+// ExampleArchitecture_Service adds one piece of the system, with the icon it is
+// drawn as.
+func ExampleArchitecture_Service() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Service("api", arch.IconServer, "API").
+		Service("db", arch.IconDatabase, "Database").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     service api(server)[API]
+	//     service db(database)[Database]
+}
+
+// ExampleArchitecture_ServiceInGroup puts a service inside a group, which is
+// how a diagram says which things sit together.
+func ExampleArchitecture_ServiceInGroup() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Group("cloud", arch.IconCloud, "Cloud").
+		ServiceInGroup("api", arch.IconServer, "API", "cloud").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     group cloud(cloud)[Cloud]
+	//     service api(server)[API] in cloud
+}
+
+// ExampleArchitecture_Group adds a box the services can sit in.
+func ExampleArchitecture_Group() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Group("cloud", arch.IconCloud, "Cloud").
+		Group("onprem", arch.IconServer, "On premise").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     group cloud(cloud)[Cloud]
+	//     group onprem(server)[On premise]
+}
+
+// ExampleArchitecture_GroupInParentGroup nests one group inside another, for a
+// region holding a cluster holding services.
+func ExampleArchitecture_GroupInParentGroup() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Group("cloud", arch.IconCloud, "Cloud").
+		GroupInParentGroup("cluster", arch.IconServer, "Cluster", "cloud").
+		ServiceInGroup("api", arch.IconServer, "API", "cluster").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     group cloud(cloud)[Cloud]
+	//     group cluster(server)[Cluster] in cloud
+	//     service api(server)[API] in cluster
+}
+
+// ExampleArchitecture_Edges joins two services. Each end says which side of its
+// service the line leaves from and whether it carries an arrowhead.
+func ExampleArchitecture_Edges() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Service("api", arch.IconServer, "API").
+		Service("db", arch.IconDatabase, "Database").
+		Edges(
+			arch.Edge{ServiceID: "api", Position: arch.PositionRight, Arrow: arch.ArrowNone},
+			arch.Edge{ServiceID: "db", Position: arch.PositionLeft, Arrow: arch.ArrowRight},
+		).
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     service api(server)[API]
+	//     service db(database)[Database]
+	//     api:R --> L:db
+}
+
+// ExampleArchitecture_EdgesInAnothorGroup joins two services that are in
+// different groups, which mermaid draws differently from an edge inside one.
+func ExampleArchitecture_EdgesInAnothorGroup() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Group("cloud", arch.IconCloud, "Cloud").
+		Group("onprem", arch.IconServer, "On premise").
+		ServiceInGroup("api", arch.IconServer, "API", "cloud").
+		ServiceInGroup("db", arch.IconDatabase, "Database", "onprem").
+		EdgesInAnothorGroup(
+			arch.Edge{ServiceID: "api", Position: arch.PositionRight, Arrow: arch.ArrowNone},
+			arch.Edge{ServiceID: "db", Position: arch.PositionLeft, Arrow: arch.ArrowRight},
+		).
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     group cloud(cloud)[Cloud]
+	//     group onprem(server)[On premise]
+	//     service api(server)[API] in cloud
+	//     service db(database)[Database] in onprem
+	//     api{group}:R --> L:db{group}
+}
+
+// ExampleArchitecture_Junction adds a point several edges can meet at, so a
+// diagram can route lines around each other rather than across.
+func ExampleArchitecture_Junction() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Service("api", arch.IconServer, "API").
+		Junction("j1").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     service api(server)[API]
+	//     junction j1
+}
+
+// ExampleArchitecture_JunctionsInParent puts a junction inside a group.
+func ExampleArchitecture_JunctionsInParent() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Group("cloud", arch.IconCloud, "Cloud").
+		JunctionsInParent("j1", "cloud").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     group cloud(cloud)[Cloud]
+	//     junction j1 in cloud
+}
+
+// ExampleArchitecture_String returns the diagram without needing a writer,
+// which is how it is handed to a markdown code block.
+func ExampleArchitecture_String() {
+	diagram := arch.NewArchitecture(io.Discard).
+		Service("api", arch.IconServer, "API").
+		String()
+
+	_ = markdown.NewMarkdown(os.Stdout).
+		CodeBlocks(markdown.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// architecture-beta
+	//     service api(server)[API]
+	// ```
+}
+
+// ExampleArchitecture_Build writes the diagram and reports the error the chain
+// recorded.
+func ExampleArchitecture_Build() {
+	err := arch.NewArchitecture(nil).Service("api", arch.IconServer, "API").Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleArchitecture_Error reports the same error Build does, for code that
+// wants to look before writing anything.
+func ExampleArchitecture_Error() {
+	a := arch.NewArchitecture(io.Discard).Service("api", arch.IconServer, "API")
+	fmt.Println("error:", a.Error())
+
+	// Output:
+	// error: <nil>
+}
+
+// ExampleArchitecture_LF adds a blank line to the diagram body.
+func ExampleArchitecture_LF() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Service("api", arch.IconServer, "API").
+		LF().
+		Service("db", arch.IconDatabase, "Database").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     service api(server)[API]
+	//
+	//     service db(database)[Database]
+}
+
+// ExampleIcon shows the icons a service or a group can be drawn as.
+func ExampleIcon() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Service("a", arch.IconCloud, "Cloud").
+		Service("b", arch.IconDatabase, "Database").
+		Service("c", arch.IconDisk, "Disk").
+		Service("d", arch.IconInternet, "Internet").
+		Service("e", arch.IconServer, "Server").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     service a(cloud)[Cloud]
+	//     service b(database)[Database]
+	//     service c(disk)[Disk]
+	//     service d(internet)[Internet]
+	//     service e(server)[Server]
+}
+
+// ExampleEdge shows what one end of a line is: the service it leaves, the side
+// it leaves from, and whether it carries an arrowhead.
+func ExampleEdge() {
+	from := arch.Edge{ServiceID: "api", Position: arch.PositionRight, Arrow: arch.ArrowNone}
+	to := arch.Edge{ServiceID: "db", Position: arch.PositionLeft, Arrow: arch.ArrowRight}
+
+	_ = arch.NewArchitecture(os.Stdout).
+		Service("api", arch.IconServer, "API").
+		Service("db", arch.IconDatabase, "Database").
+		Edges(from, to).
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     service api(server)[API]
+	//     service db(database)[Database]
+	//     api:R --> L:db
+}
+
+// ExamplePosition shows the four sides of a service a line can leave from.
+func ExamplePosition() {
+	for _, position := range []arch.Position{
+		arch.PositionTop, arch.PositionBottom, arch.PositionLeft, arch.PositionRight,
+	} {
+		_ = arch.NewArchitecture(os.Stdout).
+			Service("api", arch.IconServer, "API").
+			Service("db", arch.IconDatabase, "Database").
+			Edges(
+				arch.Edge{ServiceID: "api", Position: position, Arrow: arch.ArrowNone},
+				arch.Edge{ServiceID: "db", Position: arch.PositionLeft, Arrow: arch.ArrowNone},
+			).
+			Build()
+		fmt.Println()
+	}
+
+	// Output:
+	// architecture-beta
+	//     service api(server)[API]
+	//     service db(database)[Database]
+	//     api:T -- L:db
+	// architecture-beta
+	//     service api(server)[API]
+	//     service db(database)[Database]
+	//     api:B -- L:db
+	// architecture-beta
+	//     service api(server)[API]
+	//     service db(database)[Database]
+	//     api:L -- L:db
+	// architecture-beta
+	//     service api(server)[API]
+	//     service db(database)[Database]
+	//     api:R -- L:db
+}
+
+// ExampleArrow shows what an end of a line can carry.
+func ExampleArrow() {
+	_ = arch.NewArchitecture(os.Stdout).
+		Service("api", arch.IconServer, "API").
+		Service("db", arch.IconDatabase, "Database").
+		Edges(
+			arch.Edge{ServiceID: "api", Position: arch.PositionRight, Arrow: arch.ArrowLeft},
+			arch.Edge{ServiceID: "db", Position: arch.PositionLeft, Arrow: arch.ArrowRight},
+		).
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     service api(server)[API]
+	//     service db(database)[Database]
+	//     api:R <--> L:db
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewArchitecture.
+func ExampleOption() {
+	options := []arch.Option{}
+
+	_ = arch.NewArchitecture(os.Stdout, options...).
+		Service("api", arch.IconServer, "API").
+		Build()
+
+	// Output:
+	// architecture-beta
+	//     service api(server)[API]
 }

--- a/mermaid/block/examples_test.go
+++ b/mermaid/block/examples_test.go
@@ -3,6 +3,7 @@
 package block_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -57,4 +58,556 @@ func ExampleDiagram() {
 	//     Backend --> Database
 	//     Backend -- "reads from" --> Cache
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every block diagram has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a", block.WithNodeLabel("A"))).
+		Build()
+
+	// Output:
+	// block
+	//     a["A"]
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := block.NewDiagram(io.Discard).
+		Row(block.Node("a", block.WithNodeLabel("A"))).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// block
+	//     a["A"]
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := block.NewDiagram(nil).
+		Row(block.Node("a", block.WithNodeLabel("A"))).
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := block.NewDiagram(io.Discard).
+		Columns(0)
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: column count must be greater than zero
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a", block.WithNodeLabel("A"))).
+		LF().
+		Row(block.Node("a", block.WithNodeLabel("A"))).
+		Build()
+
+	// Output:
+	// block
+	//     a["A"]
+	//
+	//     a["A"]
+}
+
+// ExampleDiagram_full shows a block diagram built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := block.NewDiagram(io.Discard).
+		Row(block.Node("a", block.WithNodeLabel("A"))).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// block
+	//     a["A"]
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []block.Option{block.WithTitle("Overview")}
+
+	_ = block.NewDiagram(os.Stdout, options...).
+		Row(block.Node("a", block.WithNodeLabel("A"))).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// block
+	//     a["A"]
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = block.NewDiagram(os.Stdout, block.WithTitle("Overview")).
+		Row(block.Node("a", block.WithNodeLabel("A"))).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// block
+	//     a["A"]
+}
+
+// ExampleDiagram_Row puts a line of blocks in the diagram. Everything on a row
+// is drawn side by side.
+func ExampleDiagram_Row() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(
+			block.Node("a", block.WithNodeLabel("Ingest")),
+			block.Node("b", block.WithNodeLabel("Process")),
+		).
+		Build()
+
+	// Output:
+	// block
+	//     a["Ingest"] b["Process"]
+}
+
+// ExampleDiagram_Columns fixes how many columns the diagram is laid out in, so
+// a long row wraps where the caller wants it to rather than where mermaid does.
+func ExampleDiagram_Columns() {
+	_ = block.NewDiagram(os.Stdout).
+		Columns(2).
+		Row(
+			block.Node("a", block.WithNodeLabel("A")),
+			block.Node("b", block.WithNodeLabel("B")),
+			block.Node("c", block.WithNodeLabel("C")),
+		).
+		Build()
+
+	// Output:
+	// block
+	//     columns 2
+	//     a["A"] b["B"] c["C"]
+}
+
+// ExampleDiagram_Block opens a group of blocks drawn inside a box. The calls in
+// the function belong to it.
+func ExampleDiagram_Block() {
+	_ = block.NewDiagram(os.Stdout).
+		Block(func(d *block.Diagram) {
+			d.Row(block.Node("a", block.WithNodeLabel("Inside")))
+		}, block.WithBlockID("group")).
+		Build()
+
+	// Output:
+	// block
+	//     block:group
+	//         a["Inside"]
+	//     end
+}
+
+// ExampleDiagram_Link joins two blocks by their identifiers.
+func ExampleDiagram_Link() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.Node("b")).
+		Link("a", "b").
+		Build()
+
+	// Output:
+	// block
+	//     a b
+	//     a --> b
+}
+
+// ExampleDiagram_LinkWithLabel joins two blocks and says what the line means.
+func ExampleDiagram_LinkWithLabel() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.Node("b")).
+		LinkWithLabel("a", "publishes", "b").
+		Build()
+
+	// Output:
+	// block
+	//     a b
+	//     a -- "publishes" --> b
+}
+
+// ExampleDiagram_Statement writes a line of mermaid through unchanged, for the
+// parts of the block syntax this package has no method for.
+func ExampleDiagram_Statement() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a")).
+		Statement("style a fill:#f9f").
+		Build()
+
+	// Output:
+	// block
+	//     a
+	//     style a fill:#f9f
+}
+
+// ExampleDiagram_Style colors one block outright.
+func ExampleDiagram_Style() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a")).
+		Style("a", "fill:#f9f,stroke:#333").
+		Build()
+
+	// Output:
+	// block
+	//     a
+	//     style a fill:#f9f,stroke:#333
+}
+
+// ExampleDiagram_ClassDef names a style so several blocks can share it.
+func ExampleDiagram_ClassDef() {
+	_ = block.NewDiagram(os.Stdout).
+		ClassDef("warning", "fill:#f96").
+		Row(block.Node("a"), block.Node("b")).
+		Class("a,b", "warning").
+		Build()
+
+	// Output:
+	// block
+	//     classDef warning fill:#f96
+	//     a b
+	//     class a,b warning
+}
+
+// ExampleDiagram_Class applies a named style to blocks.
+func ExampleDiagram_Class() {
+	_ = block.NewDiagram(os.Stdout).
+		ClassDef("warning", "fill:#f96").
+		Row(block.Node("a")).
+		Class("a", "warning").
+		Build()
+
+	// Output:
+	// block
+	//     classDef warning fill:#f96
+	//     a
+	//     class a warning
+}
+
+// ExampleNode is one block. Without a label it is drawn with its identifier
+// inside, which is often all a diagram needs.
+func ExampleNode() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.Node("b", block.WithNodeLabel("With a label"))).
+		Build()
+
+	// Output:
+	// block
+	//     a b["With a label"]
+}
+
+// ExampleLiteral writes a token through unchanged, for a shape this package has
+// no option for.
+func ExampleLiteral() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Literal(`a(("Circle"))`)).
+		Build()
+
+	// Output:
+	// block
+	//     a(("Circle"))
+}
+
+// ExampleSpace leaves a gap in a row, which is how a diagram lines up two rows
+// that hold different numbers of blocks.
+func ExampleSpace() {
+	_ = block.NewDiagram(os.Stdout).
+		Columns(3).
+		Row(block.Node("a"), block.Space(), block.Node("b")).
+		Row(block.Node("c"), block.Space(2), block.Node("d")).
+		Build()
+
+	// Output:
+	// block
+	//     columns 3
+	//     a space b
+	//     c space:2 d
+}
+
+// ExampleArrow draws an arrow token pointing the way it is told.
+func ExampleArrow() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.Arrow("ar", block.DirectionRight), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     a ar<["&nbsp;"]>(right) b
+}
+
+// ExampleArrowRight draws an arrow pointing right, which is the same as Arrow
+// with DirectionRight and shorter to read in a chain.
+func ExampleArrowRight() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.ArrowRight("ar"), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     a ar<["&nbsp;"]>(right) b
+}
+
+// ExampleArrowLeft draws an arrow pointing left.
+func ExampleArrowLeft() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.ArrowLeft("al"), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     a al<["&nbsp;"]>(left) b
+}
+
+// ExampleArrowUp draws an arrow pointing up.
+func ExampleArrowUp() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.ArrowUp("au"), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     a au<["&nbsp;"]>(up) b
+}
+
+// ExampleArrowDown draws an arrow pointing down.
+func ExampleArrowDown() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.ArrowDown("ad"), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     a ad<["&nbsp;"]>(down) b
+}
+
+// ExampleArrowX draws an arrow pointing both left and right.
+func ExampleArrowX() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.ArrowX("ax"), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     a ax<["&nbsp;"]>(x) b
+}
+
+// ExampleArrowY draws an arrow pointing both up and down.
+func ExampleArrowY() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.ArrowY("ay"), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     a ay<["&nbsp;"]>(y) b
+}
+
+// ExampleWithNodeLabel puts text inside a block instead of its identifier.
+func ExampleWithNodeLabel() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a", block.WithNodeLabel("Ingest"))).
+		Build()
+
+	// Output:
+	// block
+	//     a["Ingest"]
+}
+
+// ExampleWithNodeShape draws a block as something other than a rectangle.
+func ExampleWithNodeShape() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a", block.WithNodeLabel("Decide"), block.WithNodeShape(block.ShapeRhombus))).
+		Build()
+
+	// Output:
+	// block
+	//     a{"Decide"}
+}
+
+// ExampleWithNodeSpan makes one block as wide as several columns.
+func ExampleWithNodeSpan() {
+	_ = block.NewDiagram(os.Stdout).
+		Columns(3).
+		Row(block.Node("a", block.WithNodeLabel("Wide"), block.WithNodeSpan(2)), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     columns 3
+	//     a["Wide"]:2 b
+}
+
+// ExampleWithBlockID names a group of blocks.
+func ExampleWithBlockID() {
+	_ = block.NewDiagram(os.Stdout).
+		Block(func(d *block.Diagram) {
+			d.Row(block.Node("a"))
+		}, block.WithBlockID("group")).
+		Build()
+
+	// Output:
+	// block
+	//     block:group
+	//         a
+	//     end
+}
+
+// ExampleWithBlockSpan makes a group as wide as several columns.
+func ExampleWithBlockSpan() {
+	_ = block.NewDiagram(os.Stdout).
+		Columns(3).
+		Block(func(d *block.Diagram) {
+			d.Row(block.Node("a"))
+		}, block.WithBlockID("group"), block.WithBlockSpan(2)).
+		Build()
+
+	// Output:
+	// block
+	//     columns 3
+	//     block:group:2
+	//         a
+	//     end
+}
+
+// ExampleWithArrowLabel says what an arrow means.
+func ExampleWithArrowLabel() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.ArrowRight("ar", block.WithArrowLabel("publishes")), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     a ar<["publishes"]>(right) b
+}
+
+// ExampleWithArrowSecondaryDirection points an arrow two ways at once.
+func ExampleWithArrowSecondaryDirection() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(
+			block.Node("a"),
+			block.ArrowRight("ar", block.WithArrowSecondaryDirection(block.DirectionDown)),
+			block.Node("b"),
+		).
+		Build()
+
+	// Output:
+	// block
+	//     a ar<["&nbsp;"]>(right, down) b
+}
+
+// ExampleToken is what a row is made of: a node, an arrow, a gap or a literal.
+func ExampleToken() {
+	tokens := []block.Token{
+		block.Node("a", block.WithNodeLabel("Ingest")),
+		block.ArrowRight("ar"),
+		block.Node("b", block.WithNodeLabel("Process")),
+	}
+
+	_ = block.NewDiagram(os.Stdout).Row(tokens...).Build()
+
+	// Output:
+	// block
+	//     a["Ingest"] ar<["&nbsp;"]>(right) b["Process"]
+}
+
+// ExampleShape shows the shapes a block can be drawn as.
+func ExampleShape() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(
+			block.Node("a", block.WithNodeShape(block.ShapeRound)),
+			block.Node("b", block.WithNodeShape(block.ShapeStadium)),
+			block.Node("c", block.WithNodeShape(block.ShapeRhombus)),
+		).
+		Build()
+
+	// Output:
+	// block
+	//     a("a") b(["b"]) c{"c"}
+}
+
+// ExampleDirection shows the ways an arrow can point.
+func ExampleDirection() {
+	_ = block.NewDiagram(os.Stdout).
+		Row(
+			block.Arrow("a", block.DirectionRight),
+			block.Arrow("b", block.DirectionLeft),
+			block.Arrow("c", block.DirectionUp),
+			block.Arrow("d", block.DirectionDown),
+		).
+		Build()
+
+	// Output:
+	// block
+	//     a<["&nbsp;"]>(right) b<["&nbsp;"]>(left) c<["&nbsp;"]>(up) d<["&nbsp;"]>(down)
+}
+
+// ExampleNodeOption shows what a NodeOption is: a function that changes how a
+// block is written, passed to Node after its identifier.
+func ExampleNodeOption() {
+	options := []block.NodeOption{block.WithNodeLabel("Ingest"), block.WithNodeSpan(2)}
+
+	_ = block.NewDiagram(os.Stdout).Columns(3).Row(block.Node("a", options...)).Build()
+
+	// Output:
+	// block
+	//     columns 3
+	//     a["Ingest"]:2
+}
+
+// ExampleBlockOption shows what a BlockOption is: a function that changes how a
+// group is written, passed to Block after the function that fills it.
+func ExampleBlockOption() {
+	options := []block.BlockOption{block.WithBlockID("group")}
+
+	_ = block.NewDiagram(os.Stdout).
+		Block(func(d *block.Diagram) { d.Row(block.Node("a")) }, options...).
+		Build()
+
+	// Output:
+	// block
+	//     block:group
+	//         a
+	//     end
+}
+
+// ExampleArrowOption shows what an ArrowOption is: a function that changes how
+// an arrow is written, passed to one of the arrow constructors.
+func ExampleArrowOption() {
+	options := []block.ArrowOption{block.WithArrowLabel("publishes")}
+
+	_ = block.NewDiagram(os.Stdout).
+		Row(block.Node("a"), block.ArrowRight("ar", options...), block.Node("b")).
+		Build()
+
+	// Output:
+	// block
+	//     a ar<["publishes"]>(right) b
 }

--- a/mermaid/c4/examples_test.go
+++ b/mermaid/c4/examples_test.go
@@ -3,6 +3,7 @@
 package c4_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -96,4 +97,386 @@ func ExampleDiagram_quoting() {
 	//     title Ledger #35;1#59; the "core"
 	//     System(ledger, "The #quot;Core#quot; Ledger", "Tracks #35;1 of everything.")
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every C4 context diagram has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = c4.NewDiagram(os.Stdout).
+		Person("customer", "Customer").System("ledger", "Ledger").
+		Build()
+
+	// Output:
+	// C4Context
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := c4.NewDiagram(io.Discard).
+		Person("customer", "Customer").System("ledger", "Ledger").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// C4Context
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := c4.NewDiagram(nil).
+		Person("customer", "Customer").System("ledger", "Ledger").
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := c4.NewDiagram(io.Discard).
+		BoundaryEnd()
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: BoundaryEnd was called outside a boundary; there is nothing to close
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = c4.NewDiagram(os.Stdout).
+		Person("customer", "Customer").System("ledger", "Ledger").
+		LF().
+		Person("customer", "Customer").System("ledger", "Ledger").
+		Build()
+
+	// Output:
+	// C4Context
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+	//
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+}
+
+// ExampleDiagram_full shows a C4 context diagram built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := c4.NewDiagram(io.Discard).
+		Person("customer", "Customer").System("ledger", "Ledger").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// C4Context
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []c4.Option{c4.WithTitle("Overview")}
+
+	_ = c4.NewDiagram(os.Stdout, options...).
+		Person("customer", "Customer").System("ledger", "Ledger").
+		Build()
+
+	// Output:
+	// C4Context
+	//     title Overview
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = c4.NewDiagram(os.Stdout, c4.WithTitle("Overview")).
+		Person("customer", "Customer").System("ledger", "Ledger").
+		Build()
+
+	// Output:
+	// C4Context
+	//     title Overview
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+}
+
+// ExampleDiagram_Person adds someone inside the enterprise being described.
+func ExampleDiagram_Person() {
+	_ = c4.NewDiagram(os.Stdout).
+		Person("customer", "Personal Banking Customer").
+		Build()
+
+	// Output:
+	// C4Context
+	//     Person(customer, "Personal Banking Customer")
+}
+
+// ExampleDiagram_PersonExt adds someone outside it, which mermaid draws in a
+// colder color.
+func ExampleDiagram_PersonExt() {
+	_ = c4.NewDiagram(os.Stdout).
+		PersonExt("auditor", "External Auditor").
+		Build()
+
+	// Output:
+	// C4Context
+	//     Person_Ext(auditor, "External Auditor")
+}
+
+// ExampleDiagram_System adds a software system inside the enterprise.
+func ExampleDiagram_System() {
+	_ = c4.NewDiagram(os.Stdout).
+		System("banking", "Internet Banking System").
+		Build()
+
+	// Output:
+	// C4Context
+	//     System(banking, "Internet Banking System")
+}
+
+// ExampleDiagram_SystemExt adds a software system outside it.
+func ExampleDiagram_SystemExt() {
+	_ = c4.NewDiagram(os.Stdout).
+		SystemExt("mail", "E-mail System").
+		Build()
+
+	// Output:
+	// C4Context
+	//     System_Ext(mail, "E-mail System")
+}
+
+// ExampleDiagram_SystemDb adds a software system drawn as a database.
+func ExampleDiagram_SystemDb() {
+	_ = c4.NewDiagram(os.Stdout).
+		SystemDb("accounts", "Accounts Database").
+		Build()
+
+	// Output:
+	// C4Context
+	//     SystemDb(accounts, "Accounts Database")
+}
+
+// ExampleDiagram_SystemQueue adds a software system drawn as a queue.
+func ExampleDiagram_SystemQueue() {
+	_ = c4.NewDiagram(os.Stdout).
+		SystemQueue("events", "Event Bus").
+		Build()
+
+	// Output:
+	// C4Context
+	//     SystemQueue(events, "Event Bus")
+}
+
+// ExampleDiagram_Boundary opens a box the elements after it are drawn inside.
+// BoundaryEnd closes it, and leaving one open is reported from Build because
+// mermaid refuses a diagram whose brace never closes.
+func ExampleDiagram_Boundary() {
+	_ = c4.NewDiagram(os.Stdout).
+		Boundary("region", "eu-west-1", c4.WithBoundaryType("region")).
+		System("api", "Public API").
+		BoundaryEnd().
+		Build()
+
+	// Output:
+	// C4Context
+	//     Boundary(region, "eu-west-1", "region") {
+	//         System(api, "Public API")
+	//     }
+}
+
+// ExampleDiagram_EnterpriseBoundary opens a boundary drawn as the enterprise.
+func ExampleDiagram_EnterpriseBoundary() {
+	_ = c4.NewDiagram(os.Stdout).
+		EnterpriseBoundary("bank", "Big Bank plc").
+		Person("customer", "Customer").
+		BoundaryEnd().
+		Build()
+
+	// Output:
+	// C4Context
+	//     Enterprise_Boundary(bank, "Big Bank plc") {
+	//         Person(customer, "Customer")
+	//     }
+}
+
+// ExampleDiagram_SystemBoundary opens a boundary drawn as a software system,
+// and boundaries nest.
+func ExampleDiagram_SystemBoundary() {
+	_ = c4.NewDiagram(os.Stdout).
+		EnterpriseBoundary("bank", "Big Bank plc").
+		SystemBoundary("banking", "Internet Banking").
+		System("web", "Web Application").
+		BoundaryEnd().
+		BoundaryEnd().
+		Build()
+
+	// Output:
+	// C4Context
+	//     Enterprise_Boundary(bank, "Big Bank plc") {
+	//         System_Boundary(banking, "Internet Banking") {
+	//             System(web, "Web Application")
+	//         }
+	//     }
+}
+
+// ExampleDiagram_BoundaryEnd closes the boundary opened last. Calling it
+// outside one is an error rather than a silent no-op.
+func ExampleDiagram_BoundaryEnd() {
+	_ = c4.NewDiagram(os.Stdout).
+		Boundary("region", "eu-west-1").
+		System("api", "Public API").
+		BoundaryEnd().
+		System("outside", "Somewhere Else").
+		Build()
+
+	// Output:
+	// C4Context
+	//     Boundary(region, "eu-west-1") {
+	//         System(api, "Public API")
+	//     }
+	//     System(outside, "Somewhere Else")
+}
+
+// ExampleDiagram_Rel draws a one way relationship.
+func ExampleDiagram_Rel() {
+	_ = c4.NewDiagram(os.Stdout).
+		Person("customer", "Customer").
+		System("ledger", "Ledger").
+		Rel("customer", "ledger", "Views balances", c4.WithTechnology("HTTPS")).
+		Build()
+
+	// Output:
+	// C4Context
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+	//     Rel(customer, ledger, "Views balances", "HTTPS")
+}
+
+// ExampleDiagram_BiRel draws a relationship with an arrowhead at each end.
+func ExampleDiagram_BiRel() {
+	_ = c4.NewDiagram(os.Stdout).
+		System("web", "Web Application").
+		SystemDb("accounts", "Accounts Database").
+		BiRel("web", "accounts", "Reads from and writes to", c4.WithTechnology("SQL/TCP")).
+		Build()
+
+	// Output:
+	// C4Context
+	//     System(web, "Web Application")
+	//     SystemDb(accounts, "Accounts Database")
+	//     BiRel(web, accounts, "Reads from and writes to", "SQL/TCP")
+}
+
+// ExampleWithDescription puts a sentence under an element's label.
+func ExampleWithDescription() {
+	_ = c4.NewDiagram(os.Stdout).
+		Person("customer", "Customer", c4.WithDescription("A customer of the bank.")).
+		Build()
+
+	// Output:
+	// C4Context
+	//     Person(customer, "Customer", "A customer of the bank.")
+}
+
+// ExampleWithTechnology says how two things talk to each other, drawn in
+// brackets on the arrow.
+func ExampleWithTechnology() {
+	_ = c4.NewDiagram(os.Stdout).
+		Person("customer", "Customer").
+		System("ledger", "Ledger").
+		Rel("customer", "ledger", "Views balances", c4.WithTechnology("HTTPS (TLS 1.3)")).
+		Build()
+
+	// Output:
+	// C4Context
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+	//     Rel(customer, ledger, "Views balances", "HTTPS (TLS 1.3)")
+}
+
+// ExampleWithBoundaryType puts a tag in brackets beside a boundary's label.
+// EnterpriseBoundary and SystemBoundary carry their own, so this applies to
+// Boundary alone.
+func ExampleWithBoundaryType() {
+	_ = c4.NewDiagram(os.Stdout).
+		Boundary("regulator", "Regulator", c4.WithBoundaryType("external")).
+		SystemExt("reporting", "Regulatory Reporting").
+		BoundaryEnd().
+		Build()
+
+	// Output:
+	// C4Context
+	//     Boundary(regulator, "Regulator", "external") {
+	//         System_Ext(reporting, "Regulatory Reporting")
+	//     }
+}
+
+// ExampleElementOption shows what an ElementOption is: a function that changes
+// how an element is written, passed after its label.
+func ExampleElementOption() {
+	options := []c4.ElementOption{c4.WithDescription("A customer of the bank.")}
+
+	_ = c4.NewDiagram(os.Stdout).Person("customer", "Customer", options...).Build()
+
+	// Output:
+	// C4Context
+	//     Person(customer, "Customer", "A customer of the bank.")
+}
+
+// ExampleRelationOption shows what a RelationOption is: a function that changes
+// how a relationship is written, passed after its label.
+func ExampleRelationOption() {
+	options := []c4.RelationOption{c4.WithTechnology("HTTPS")}
+
+	_ = c4.NewDiagram(os.Stdout).
+		Person("customer", "Customer").
+		System("ledger", "Ledger").
+		Rel("customer", "ledger", "Views balances", options...).
+		Build()
+
+	// Output:
+	// C4Context
+	//     Person(customer, "Customer")
+	//     System(ledger, "Ledger")
+	//     Rel(customer, ledger, "Views balances", "HTTPS")
+}
+
+// ExampleBoundaryOption shows what a BoundaryOption is: a function that changes
+// how a boundary is written, passed after its label.
+func ExampleBoundaryOption() {
+	options := []c4.BoundaryOption{c4.WithBoundaryType("region")}
+
+	_ = c4.NewDiagram(os.Stdout).
+		Boundary("region", "eu-west-1", options...).
+		System("api", "Public API").
+		BoundaryEnd().
+		Build()
+
+	// Output:
+	// C4Context
+	//     Boundary(region, "eu-west-1", "region") {
+	//         System(api, "Public API")
+	//     }
 }

--- a/mermaid/class/examples_test.go
+++ b/mermaid/class/examples_test.go
@@ -3,6 +3,7 @@
 package class_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -72,4 +73,925 @@ func ExampleDiagram() {
 	//     Order --> PaymentGateway : uses
 	//     note for Order "Aggregate Root"
 	// ```
+}
+
+// ExampleDiagram_Composition draws a composition, the diamond that says the whole owns the part.
+func ExampleDiagram_Composition() {
+	_ = class.NewDiagram(os.Stdout).
+		Composition("Order", "LineItem").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order *-- LineItem
+}
+
+// ExampleDiagram_CompositionWithLabel draws it and says what it means.
+func ExampleDiagram_CompositionWithLabel() {
+	_ = class.NewDiagram(os.Stdout).
+		CompositionWithLabel("Order", "LineItem", "holds").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order *-- LineItem : holds
+}
+
+// ExampleDiagram_CompositionWithCardinality draws it and says how many of each.
+func ExampleDiagram_CompositionWithCardinality() {
+	_ = class.NewDiagram(os.Stdout).
+		CompositionWithCardinality("Order", "1", "LineItem", "1..*").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" *-- "1..*" LineItem
+}
+
+// ExampleDiagram_CompositionWithCardinalityAndLabel draws it with both.
+func ExampleDiagram_CompositionWithCardinalityAndLabel() {
+	_ = class.NewDiagram(os.Stdout).
+		CompositionWithCardinalityAndLabel("Order", "1", "LineItem", "1..*", "holds").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" *-- "1..*" LineItem : holds
+}
+
+// ExampleDiagram_Association draws an association, the plain arrow between two classes.
+func ExampleDiagram_Association() {
+	_ = class.NewDiagram(os.Stdout).
+		Association("Order", "LineItem").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order --> LineItem
+}
+
+// ExampleDiagram_AssociationWithLabel draws it and says what it means.
+func ExampleDiagram_AssociationWithLabel() {
+	_ = class.NewDiagram(os.Stdout).
+		AssociationWithLabel("Order", "LineItem", "holds").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order --> LineItem : holds
+}
+
+// ExampleDiagram_AssociationWithCardinality draws it and says how many of each.
+func ExampleDiagram_AssociationWithCardinality() {
+	_ = class.NewDiagram(os.Stdout).
+		AssociationWithCardinality("Order", "1", "LineItem", "1..*").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" --> "1..*" LineItem
+}
+
+// ExampleDiagram_AssociationWithCardinalityAndLabel draws it with both.
+func ExampleDiagram_AssociationWithCardinalityAndLabel() {
+	_ = class.NewDiagram(os.Stdout).
+		AssociationWithCardinalityAndLabel("Order", "1", "LineItem", "1..*", "holds").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" --> "1..*" LineItem : holds
+}
+
+// ExampleWithPublicField declares a field anything can read.
+func ExampleWithPublicField() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithPublicField("string", "id")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         +string id
+	//     }
+}
+
+// ExampleWithPrivateField declares a field only the class can read.
+func ExampleWithPrivateField() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithPrivateField("int", "total")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         -int total
+	//     }
+}
+
+// ExampleWithProtectedField declares a field the class and its children can read.
+func ExampleWithProtectedField() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithProtectedField("string", "status")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         #string status
+	//     }
+}
+
+// ExampleWithPackageField declares a field the package can read.
+func ExampleWithPackageField() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithPackageField("time.Time", "createdAt")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         ~time.Time createdAt
+	//     }
+}
+
+// ExampleWithPublicMethod declares a method anything can call.
+func ExampleWithPublicMethod() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithPublicMethod("Pay", "error")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         +Pay() error
+	//     }
+}
+
+// ExampleWithPrivateMethod declares a method only the class can call.
+func ExampleWithPrivateMethod() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithPrivateMethod("recalculate", "")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         -recalculate()
+	//     }
+}
+
+// ExampleWithProtectedMethod declares a method the class and its children can call.
+func ExampleWithProtectedMethod() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithProtectedMethod("validate", "error")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         #validate() error
+	//     }
+}
+
+// ExampleWithPackageMethod declares a method the package can call.
+func ExampleWithPackageMethod() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithPackageMethod("audit", "error")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         ~audit() error
+	//     }
+}
+
+// ExampleNewDiagram shows the shape every class diagram has: a writer, the
+// classes, what relates them, and Build.
+func ExampleNewDiagram() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithPublicField("string", "id"), class.WithPublicMethod("Pay", "error")).
+		Class("LineItem", class.WithPublicField("string", "sku")).
+		CompositionWithCardinality("Order", "1", "LineItem", "1..*").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         +string id
+	//         +Pay() error
+	//     }
+	//     class LineItem {
+	//         +string sku
+	//     }
+	//     Order "1" *-- "1..*" LineItem
+}
+
+// ExampleDiagram_Class declares a class with its members. Without any it is
+// drawn as an empty box.
+func ExampleDiagram_Class() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order",
+			class.WithPublicField("string", "id"),
+			class.WithPrivateField("int", "total"),
+			class.WithPublicMethod("Pay", "error"),
+		).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         +string id
+	//         -int total
+	//         +Pay() error
+	//     }
+}
+
+// ExampleDiagram_ClassWithMembers declares a class from members already built,
+// for a diagram assembled from data rather than written out.
+func ExampleDiagram_ClassWithMembers() {
+	_ = class.NewDiagram(os.Stdout).
+		ClassWithMembers("Order", "+string id", "+Pay() error").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         +string id
+	//         +Pay() error
+	//     }
+}
+
+// ExampleDiagram_ClassWithLabel gives a class a label to be drawn under,
+// where its identifier is not what a reader should see.
+func ExampleDiagram_ClassWithLabel() {
+	_ = class.NewDiagram(os.Stdout).
+		ClassWithLabel("Order", "Customer Order").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order["Customer Order"]
+}
+
+// ExampleDiagram_ClassWithAnnotation declares a class and what kind of thing it
+// is, drawn above the name in guillemets.
+func ExampleDiagram_ClassWithAnnotation() {
+	_ = class.NewDiagram(os.Stdout).
+		ClassWithAnnotation("Payable", "Interface").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Payable {
+	//         <<Interface>>
+	//     }
+}
+
+// ExampleDiagram_Annotation says what kind of thing a class is, separately from
+// declaring it.
+func ExampleDiagram_Annotation() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Payable").
+		Annotation("Payable", "Interface").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Payable
+	//     class Payable {
+	//         <<Interface>>
+	//     }
+}
+
+// ExampleDiagram_Interface annotates a class as an interface, which is the same
+// as Annotation with "Interface" and shorter to read in a chain.
+func ExampleDiagram_Interface() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Payable", class.WithPublicMethod("Pay", "error")).
+		Interface("Payable").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Payable {
+	//         +Pay() error
+	//     }
+	//     class Payable {
+	//         <<Interface>>
+	//     }
+}
+
+// ExampleDiagram_Member adds one member to a class already declared, using
+// mermaid's "Class : member" form.
+func ExampleDiagram_Member() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order").
+		Member("Order", "+string id").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order
+	//     Order : +string id
+}
+
+// ExampleDiagram_Relation joins two classes with a relationship named outright,
+// for code that decides between them rather than picking one.
+func ExampleDiagram_Relation() {
+	_ = class.NewDiagram(os.Stdout).
+		Relation("Order", class.RelationshipInheritance, "Document").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order <|-- Document
+}
+
+// ExampleDiagram_RelationWithLabel joins two classes and says what the line
+// means.
+func ExampleDiagram_RelationWithLabel() {
+	_ = class.NewDiagram(os.Stdout).
+		RelationWithLabel("Order", class.RelationshipAssociation, "Customer", "belongs to").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order --> Customer : belongs to
+}
+
+// ExampleDiagram_RelationWithCardinality joins two classes and says how many of
+// each.
+func ExampleDiagram_RelationWithCardinality() {
+	_ = class.NewDiagram(os.Stdout).
+		RelationWithCardinality("Order", "many",
+			class.RelationshipAssociation, "Customer", "1").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "many" --> "1" Customer
+}
+
+// ExampleDiagram_RelationWithCardinalityAndLabel joins two classes with both.
+func ExampleDiagram_RelationWithCardinalityAndLabel() {
+	_ = class.NewDiagram(os.Stdout).
+		RelationWithCardinalityAndLabel("Order", "many",
+			class.RelationshipAssociation, "Customer", "1", "belongs to").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "many" --> "1" Customer : belongs to
+}
+
+// ExampleDiagram_From names a source once and hangs several relationships off
+// it, which keeps a class with many links readable.
+func ExampleDiagram_From() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Composition("LineItem", class.WithOneToMany()).
+		Association("Customer", class.WithRelationLabel("belongs to")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" *-- "many" LineItem
+	//     Order --> Customer : belongs to
+}
+
+// ExampleSourceRelationBuilder shows what From returns: the same source, with
+// one relationship per call.
+func ExampleSourceRelationBuilder() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Composition("LineItem").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order *-- LineItem
+}
+
+// ExampleSourceRelationBuilder_Composition draws a composition from the source.
+func ExampleSourceRelationBuilder_Composition() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Composition("LineItem", class.WithOneToMany()).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" *-- "many" LineItem
+}
+
+// ExampleSourceRelationBuilder_Association draws an association from the
+// source.
+func ExampleSourceRelationBuilder_Association() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Association("Customer", class.WithRelationLabel("belongs to")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order --> Customer : belongs to
+}
+
+// ExampleSourceRelationBuilder_Relation draws a relationship named outright
+// from the source.
+func ExampleSourceRelationBuilder_Relation() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Relation(class.RelationshipInheritance, "Document").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order <|-- Document
+}
+
+// ExampleDiagram_LollipopInterface draws the circle-on-a-stick that says a
+// class provides an interface.
+func ExampleDiagram_LollipopInterface() {
+	_ = class.NewDiagram(os.Stdout).
+		LollipopInterface("Payable", "Order").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Payable ()-- Order
+}
+
+// ExampleDiagram_LollipopInterfaceReverse draws it the other way round, from
+// the class to the interface.
+func ExampleDiagram_LollipopInterfaceReverse() {
+	_ = class.NewDiagram(os.Stdout).
+		LollipopInterfaceReverse("Order", "Payable").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order --() Payable
+}
+
+// ExampleDiagram_Note puts a note in the diagram, attached to nothing.
+func ExampleDiagram_Note() {
+	_ = class.NewDiagram(os.Stdout).
+		Note("Generated from the domain model").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     note "Generated from the domain model"
+}
+
+// ExampleDiagram_NoteFor puts a note beside one class.
+func ExampleDiagram_NoteFor() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order").
+		NoteFor("Order", "Immutable once paid").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order
+	//     note for Order "Immutable once paid"
+}
+
+// ExampleDiagram_Comment writes a mermaid comment, which is in the source and
+// not in the drawing.
+func ExampleDiagram_Comment() {
+	_ = class.NewDiagram(os.Stdout).
+		Comment("generated by the schema exporter").
+		Class("Order").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     %% generated by the schema exporter
+	//     class Order
+}
+
+// ExampleDiagram_Link makes a class a link, with a tooltip.
+func ExampleDiagram_Link() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order").
+		Link("Order", "https://example.com/order", "The Order type").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order
+	//     link Order "https://example.com/order" "The Order type"
+}
+
+// ExampleDiagram_Callback makes a class call a function in the page when it is
+// clicked.
+func ExampleDiagram_Callback() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order").
+		Callback("Order", "showOrder", "Show the order").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order
+	//     callback Order "showOrder" "Show the order"
+}
+
+// ExampleDiagram_ClickCall is the click form of Callback.
+func ExampleDiagram_ClickCall() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order").
+		ClickCall("Order", "showOrder", "Show the order").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order
+	//     click Order call showOrder() "Show the order"
+}
+
+// ExampleDiagram_ClickHref is the click form of Link.
+func ExampleDiagram_ClickHref() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order").
+		ClickHref("Order", "https://example.com/order", "The Order type").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order
+	//     click Order href "https://example.com/order" "The Order type"
+}
+
+// ExampleDiagram_Style colors one class outright.
+func ExampleDiagram_Style() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order").
+		Style("Order", "fill:#f9f").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order
+	//     style Order fill:#f9f
+}
+
+// ExampleDiagram_ClassDef names a style so several classes can share it.
+func ExampleDiagram_ClassDef() {
+	_ = class.NewDiagram(os.Stdout).
+		ClassDef("aggregate", "fill:#f96").
+		Class("Order").
+		CSSClass("Order", "aggregate").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     classDef aggregate fill:#f96
+	//     class Order
+	//     cssClass "Order" aggregate;
+}
+
+// ExampleDiagram_CSSClass applies a named style to classes.
+func ExampleDiagram_CSSClass() {
+	_ = class.NewDiagram(os.Stdout).
+		ClassDef("aggregate", "fill:#f96").
+		Class("Order").
+		CSSClass("Order", "aggregate").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     classDef aggregate fill:#f96
+	//     class Order
+	//     cssClass "Order" aggregate;
+}
+
+// ExampleDiagram_ClassShorthand applies a style with mermaid's ":::" form,
+// which says the same thing as CSSClass in one token.
+func ExampleDiagram_ClassShorthand() {
+	_ = class.NewDiagram(os.Stdout).
+		ClassDef("aggregate", "fill:#f96").
+		ClassShorthand("Order", "aggregate").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     classDef aggregate fill:#f96
+	//     class Order:::aggregate
+}
+
+// ExampleDiagram_SetDirection says which way the diagram is laid out.
+func ExampleDiagram_SetDirection() {
+	_ = class.NewDiagram(os.Stdout).
+		SetDirection(class.DirectionLR).
+		Class("Order").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     direction LR
+	//     class Order
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := class.NewDiagram(io.Discard).Class("Order").String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// classDiagram
+	//     class Order
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the error the chain
+// recorded.
+func ExampleDiagram_Build() {
+	err := class.NewDiagram(nil).Class("Order").Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := class.NewDiagram(io.Discard).Class("Order")
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: <nil>
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order").
+		LF().
+		Class("LineItem").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order
+	//
+	//     class LineItem
+}
+
+// ExampleWithField declares a member with its visibility named outright, for
+// code that decides between them rather than picking one.
+func ExampleWithField() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order", class.WithField(class.VisibilityPublic, "string", "id")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         +string id
+	//     }
+}
+
+// ExampleWithMethod declares a method with its visibility named outright, and
+// with the parameters it takes.
+func ExampleWithMethod() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order",
+			class.WithMethod(class.VisibilityPublic, "Pay", "error", "amount int"),
+		).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         +Pay(amount int) error
+	//     }
+}
+
+// ExampleWithRelationLabel says what a relationship means, for the From form.
+func ExampleWithRelationLabel() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Association("Customer", class.WithRelationLabel("belongs to")).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order --> Customer : belongs to
+}
+
+// ExampleWithCardinality says how many of each end a relationship has, for the
+// From form.
+func ExampleWithCardinality() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Composition("LineItem",
+			class.WithCardinality(class.CardinalityOne, class.CardinalityOneOrMore)).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" *-- "1..*" LineItem
+}
+
+// ExampleWithOneToOne is WithCardinality for the commonest pairing, and reads
+// as what it means.
+func ExampleWithOneToOne() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Association("Invoice", class.WithOneToOne()).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" --> "1" Invoice
+}
+
+// ExampleWithOneToMany says one of the source and many of the target.
+func ExampleWithOneToMany() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Composition("LineItem", class.WithOneToMany()).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" *-- "many" LineItem
+}
+
+// ExampleWithManyToOne says many of the source and one of the target.
+func ExampleWithManyToOne() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Association("Customer", class.WithManyToOne()).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "many" --> "1" Customer
+}
+
+// ExampleWithManyToMany says many of both.
+func ExampleWithManyToMany() {
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Association("Tag", class.WithManyToMany()).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "many" --> "many" Tag
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = class.NewDiagram(os.Stdout, class.WithTitle("Checkout Domain")).
+		Class("Order").
+		Build()
+
+	// Output:
+	// ---
+	// title: "Checkout Domain"
+	// ---
+	// classDiagram
+	//     class Order
+}
+
+// ExampleCardinality shows how many of one end a relationship has.
+func ExampleCardinality() {
+	_ = class.NewDiagram(os.Stdout).
+		RelationWithCardinality("Order", string(class.CardinalityOne),
+			class.RelationshipComposition, "LineItem", string(class.CardinalityOneOrMore)).
+		RelationWithCardinality("Order", string(class.CardinalityZeroOrOne),
+			class.RelationshipAssociation, "Coupon", string(class.CardinalityZeroOrMore)).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" *-- "1..*" LineItem
+	//     Order "0..1" --> "0..*" Coupon
+}
+
+// ExampleVisibility shows the four visibilities a member can have.
+func ExampleVisibility() {
+	_ = class.NewDiagram(os.Stdout).
+		Class("Order",
+			class.WithField(class.VisibilityPublic, "string", "id"),
+			class.WithField(class.VisibilityPrivate, "int", "total"),
+			class.WithField(class.VisibilityProtected, "string", "status"),
+			class.WithField(class.VisibilityPackage, "string", "region"),
+		).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         +string id
+	//         -int total
+	//         #string status
+	//         ~string region
+	//     }
+}
+
+// ExampleRelationship shows the lines two classes can be joined with. Each has
+// a reverse, which points the same relationship the other way.
+func ExampleRelationship() {
+	_ = class.NewDiagram(os.Stdout).
+		Relation("Order", class.RelationshipInheritance, "Document").
+		Relation("Order", class.RelationshipComposition, "LineItem").
+		Relation("Order", class.RelationshipAggregation, "Coupon").
+		Relation("Order", class.RelationshipDependency, "Clock").
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order <|-- Document
+	//     Order *-- LineItem
+	//     Order o-- Coupon
+	//     Order ..> Clock
+}
+
+// ExampleDirection shows the four ways a diagram can be laid out.
+func ExampleDirection() {
+	for _, direction := range []class.Direction{
+		class.DirectionTB, class.DirectionBT, class.DirectionLR, class.DirectionRL,
+	} {
+		_ = class.NewDiagram(os.Stdout).SetDirection(direction).Class("Order").Build()
+		fmt.Println()
+	}
+
+	// Output:
+	// classDiagram
+	//     direction TB
+	//     class Order
+	// classDiagram
+	//     direction BT
+	//     class Order
+	// classDiagram
+	//     direction LR
+	//     class Order
+	// classDiagram
+	//     direction RL
+	//     class Order
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []class.Option{class.WithTitle("Checkout Domain")}
+
+	_ = class.NewDiagram(os.Stdout, options...).Class("Order").Build()
+
+	// Output:
+	// ---
+	// title: "Checkout Domain"
+	// ---
+	// classDiagram
+	//     class Order
+}
+
+// ExampleClassMemberOption shows what a ClassMemberOption is: a function that
+// declares one member, passed to Class after its name.
+func ExampleClassMemberOption() {
+	options := []class.ClassMemberOption{
+		class.WithPublicField("string", "id"),
+		class.WithPublicMethod("Pay", "error"),
+	}
+
+	_ = class.NewDiagram(os.Stdout).Class("Order", options...).Build()
+
+	// Output:
+	// classDiagram
+	//     class Order {
+	//         +string id
+	//         +Pay() error
+	//     }
+}
+
+// ExampleRelationOption shows what a RelationOption is: a function that changes
+// how a relationship from From is written.
+func ExampleRelationOption() {
+	options := []class.RelationOption{
+		class.WithOneToMany(),
+		class.WithRelationLabel("holds"),
+	}
+
+	_ = class.NewDiagram(os.Stdout).
+		From("Order").
+		Composition("LineItem", options...).
+		Build()
+
+	// Output:
+	// classDiagram
+	//     Order "1" *-- "many" LineItem : holds
 }

--- a/mermaid/er/examples_test.go
+++ b/mermaid/er/examples_test.go
@@ -3,6 +3,8 @@
 package er_test
 
 import (
+	"fmt"
+	"io"
 	"os"
 
 	"github.com/nao1215/markdown"
@@ -140,4 +142,221 @@ func ExampleDiagram() {
 	//     }
 	//
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every entity relationship diagram has: a
+// writer, a chain of calls, and Build.
+func ExampleNewDiagram() {
+	_ = er.NewDiagram(os.Stdout).
+		NoRelationship(er.NewEntity("teachers", []*er.Attribute{
+			{Type: "int", Name: "id", IsPrimaryKey: true, Comment: "Primary key"},
+		})).
+		Build()
+
+	// Output:
+	// erDiagram
+	//     teachers {
+	//         int id PK "Primary key"
+	//     }
+}
+
+// ExampleNewEntity shows how a table is described: a name and its columns. The
+// key flags put "PK", "FK" and "UK" beside a column, and the comment is drawn
+// under it.
+func ExampleNewEntity() {
+	students := er.NewEntity("students", []*er.Attribute{
+		{Type: "int", Name: "id", IsPrimaryKey: true, Comment: "Student ID"},
+		{Type: "int", Name: "teacher_id", IsForeignKey: true, Comment: "Teacher ID"},
+		{Type: "string", Name: "email", IsUniqueKey: true, Comment: "Contact address"},
+	})
+
+	_ = er.NewDiagram(os.Stdout).NoRelationship(students).Build()
+
+	// Output:
+	// erDiagram
+	//     students {
+	//         int id PK "Student ID"
+	//         int teacher_id FK "Teacher ID"
+	//         string email UK "Contact address"
+	//     }
+}
+
+// ExampleDiagram_NoRelationship adds a table that stands on its own. A diagram
+// only draws a table it has been told about, so a table with no relationships
+// needs this to appear at all.
+func ExampleDiagram_NoRelationship() {
+	_ = er.NewDiagram(os.Stdout).
+		NoRelationship(er.NewEntity("audit_log", []*er.Attribute{
+			{Type: "int", Name: "id", IsPrimaryKey: true, Comment: "Primary key"},
+		})).
+		Build()
+
+	// Output:
+	// erDiagram
+	//     audit_log {
+	//         int id PK "Primary key"
+	//     }
+}
+
+// ExampleDiagram_Relationship joins two tables. The two Relationship values are
+// the cardinality at each end, read from the left table outwards, and Identify
+// says whether the right table can exist without the left one.
+func ExampleDiagram_Relationship() {
+	teachers := er.NewEntity("teachers", []*er.Attribute{{Type: "int", Name: "id", Comment: "Primary key"}})
+	students := er.NewEntity("students", []*er.Attribute{{Type: "int", Name: "teacher_id", Comment: "Teacher ID"}})
+
+	_ = er.NewDiagram(os.Stdout).
+		Relationship(
+			teachers, students,
+			er.ExactlyOneRelationship, er.ZeroToMoreRelationship,
+			er.Identifying,
+			"teaches",
+		).
+		Build()
+
+	// Output:
+	// erDiagram
+	//     teachers ||--o{ students : "teaches"
+	//     students {
+	//         int teacher_id  "Teacher ID"
+	//     }
+	//     teachers {
+	//         int id  "Primary key"
+	//     }
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := er.NewDiagram(io.Discard).
+		NoRelationship(er.NewEntity("teachers", []*er.Attribute{{Type: "int", Name: "id", Comment: "Primary key"}})).
+		String()
+
+	_ = markdown.NewMarkdown(os.Stdout).
+		CodeBlocks(markdown.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// erDiagram
+	//     teachers {
+	//         int id  "Primary key"
+	//     }
+	//
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded.
+func ExampleDiagram_Build() {
+	err := er.NewDiagram(nil).
+		NoRelationship(er.NewEntity("teachers", []*er.Attribute{{Type: "int", Name: "id", Comment: "Primary key"}})).
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleEntity shows what a table is once described: the value NewEntity
+// returns, which the relationship calls take.
+func ExampleEntity() {
+	teachers := er.NewEntity("teachers", []*er.Attribute{
+		{Type: "int", Name: "id", IsPrimaryKey: true, Comment: "Primary key"},
+	})
+
+	_ = er.NewDiagram(os.Stdout).NoRelationship(teachers).Build()
+
+	// Output:
+	// erDiagram
+	//     teachers {
+	//         int id PK "Primary key"
+	//     }
+}
+
+// ExampleAttribute shows one column of a table. Everything but the type and the
+// name is optional.
+func ExampleAttribute() {
+	id := &er.Attribute{
+		Type:         "int",
+		Name:         "id",
+		IsPrimaryKey: true,
+		Comment:      "Primary key",
+	}
+
+	_ = er.NewDiagram(os.Stdout).
+		NoRelationship(er.NewEntity("teachers", []*er.Attribute{id})).
+		Build()
+
+	// Output:
+	// erDiagram
+	//     teachers {
+	//         int id PK "Primary key"
+	//     }
+}
+
+// ExampleRelationship shows the cardinality at one end of a relationship.
+func ExampleRelationship() {
+	teachers := er.NewEntity("teachers", []*er.Attribute{{Type: "int", Name: "id", Comment: "Primary key"}})
+	students := er.NewEntity("students", []*er.Attribute{{Type: "int", Name: "id", Comment: "Primary key"}})
+
+	_ = er.NewDiagram(os.Stdout).
+		Relationship(teachers, students,
+			er.ZeroToOneRelationship, er.OneToMoreRelationship,
+			er.NonIdentifying, "advises").
+		Build()
+
+	// Output:
+	// erDiagram
+	//     teachers |o..|{ students : "advises"
+	//     students {
+	//         int id  "Primary key"
+	//     }
+	//     teachers {
+	//         int id  "Primary key"
+	//     }
+}
+
+// ExampleIdentify says whether the right table can exist without the left one.
+// An identifying relationship is drawn with a solid line and a non identifying
+// one with a dashed line.
+func ExampleIdentify() {
+	teachers := er.NewEntity("teachers", []*er.Attribute{{Type: "int", Name: "id", Comment: "Primary key"}})
+	students := er.NewEntity("students", []*er.Attribute{{Type: "int", Name: "id", Comment: "Primary key"}})
+
+	_ = er.NewDiagram(os.Stdout).
+		Relationship(teachers, students,
+			er.ExactlyOneRelationship, er.ZeroToMoreRelationship,
+			er.Identifying, "identifying").
+		Relationship(teachers, students,
+			er.ExactlyOneRelationship, er.ZeroToMoreRelationship,
+			er.NonIdentifying, "non identifying").
+		Build()
+
+	// Output:
+	// erDiagram
+	//     teachers ||--o{ students : "identifying"
+	//     teachers ||..o{ students : "non identifying"
+	//     students {
+	//         int id  "Primary key"
+	//     }
+	//     teachers {
+	//         int id  "Primary key"
+	//     }
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []er.Option{}
+
+	_ = er.NewDiagram(os.Stdout, options...).
+		NoRelationship(er.NewEntity("teachers", []*er.Attribute{{Type: "int", Name: "id", Comment: "Primary key"}})).
+		Build()
+
+	// Output:
+	// erDiagram
+	//     teachers {
+	//         int id  "Primary key"
+	//     }
 }

--- a/mermaid/flowchart/examples_test.go
+++ b/mermaid/flowchart/examples_test.go
@@ -3,6 +3,8 @@
 package flowchart_test
 
 import (
+	"fmt"
+	"io"
 	"os"
 
 	"github.com/nao1215/markdown"
@@ -50,4 +52,490 @@ func ExampleFlowchart() {
 	//     B-->C
 	//     C-. "send filtered data" .-> D
 	// ```
+}
+
+// ExampleFlowchart_NodeWithText draws a rectangle, the default shape.
+func ExampleFlowchart_NodeWithText() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Text"]
+}
+
+// ExampleFlowchart_RoundEdgesNode draws a rectangle with rounded corners.
+func ExampleFlowchart_RoundEdgesNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		RoundEdgesNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A("Text")
+}
+
+// ExampleFlowchart_StadiumNode draws a stadium, which is a rectangle with round
+// ends.
+func ExampleFlowchart_StadiumNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		StadiumNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A(["Text"])
+}
+
+// ExampleFlowchart_SubroutineNode draws a subroutine, which carries a double
+// vertical edge.
+func ExampleFlowchart_SubroutineNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		SubroutineNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A[["Text"]]
+}
+
+// ExampleFlowchart_CylindricalNode draws a cylinder, which is how a database is
+// usually drawn.
+func ExampleFlowchart_CylindricalNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		CylindricalNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A[("Text")]
+}
+
+// ExampleFlowchart_DatabaseNode draws a cylinder. It is the same as
+// CylindricalNode, under a name that says what one is usually for.
+func ExampleFlowchart_DatabaseNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		DatabaseNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A[("Text")]
+}
+
+// ExampleFlowchart_CircleNode draws a circle.
+func ExampleFlowchart_CircleNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		CircleNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A(("Text"))
+}
+
+// ExampleFlowchart_DoubleCircleNode draws a double circle, which usually marks
+// where a flow ends.
+func ExampleFlowchart_DoubleCircleNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		DoubleCircleNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A((("Text")))
+}
+
+// ExampleFlowchart_AsymmetricNode draws a flag, flat on one side and pointed on
+// the other.
+func ExampleFlowchart_AsymmetricNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		AsymmetricNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A>"Text"]
+}
+
+// ExampleFlowchart_RhombusNode draws a diamond, which is how a decision is
+// usually drawn.
+func ExampleFlowchart_RhombusNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		RhombusNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A{"Text"}
+}
+
+// ExampleFlowchart_HexagonNode draws a hexagon.
+func ExampleFlowchart_HexagonNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		HexagonNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A{{"Text"}}
+}
+
+// ExampleFlowchart_ParallelogramNode draws a parallelogram leaning right, which
+// is how input or output is usually drawn.
+func ExampleFlowchart_ParallelogramNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		ParallelogramNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A[/"Text"/]
+}
+
+// ExampleFlowchart_ParallelogramAltNode draws a parallelogram leaning the other way.
+func ExampleFlowchart_ParallelogramAltNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		ParallelogramAltNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A[\"Text"\]
+}
+
+// ExampleFlowchart_TrapezoidNode draws a trapezoid, narrower at the top.
+func ExampleFlowchart_TrapezoidNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		TrapezoidNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A[/"Text"\]
+}
+
+// ExampleFlowchart_TrapezoidAltNode draws a trapezoid, narrower at the bottom.
+func ExampleFlowchart_TrapezoidAltNode() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		TrapezoidAltNode("A", "Text").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A[\"Text"/]
+}
+
+// ExampleFlowchart_LinkWithArrowHead joins two nodes with an arrow.
+func ExampleFlowchart_LinkWithArrowHead() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		LinkWithArrowHead("A", "B").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A-->B
+}
+
+// ExampleFlowchart_LinkWithArrowHeadAndText joins two nodes with an arrow and
+// says what it means.
+func ExampleFlowchart_LinkWithArrowHeadAndText() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		LinkWithArrowHeadAndText("A", "B", "then").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A-->|"then"|B
+}
+
+// ExampleFlowchart_OpenLink joins two nodes with a plain line, no arrowhead.
+func ExampleFlowchart_OpenLink() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		OpenLink("A", "B").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A --- B
+}
+
+// ExampleFlowchart_OpenLinkWithText joins two nodes with a plain line and a label.
+func ExampleFlowchart_OpenLinkWithText() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		OpenLinkWithText("A", "B", "and").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A---|"and"|B
+}
+
+// ExampleFlowchart_DottedLink joins two nodes with a dotted line, which usually
+// means a weaker relationship than a solid one.
+func ExampleFlowchart_DottedLink() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		DottedLink("A", "B").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A-.->B
+}
+
+// ExampleFlowchart_DottedLinkWithText joins two nodes with a dotted line and a label.
+func ExampleFlowchart_DottedLinkWithText() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		DottedLinkWithText("A", "B", "sometimes").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A-. "sometimes" .-> B
+}
+
+// ExampleFlowchart_ThickLink joins two nodes with a thick line, for the path
+// through a flow that matters most.
+func ExampleFlowchart_ThickLink() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		ThickLink("A", "B").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A ==> B
+}
+
+// ExampleFlowchart_ThickLinkWithText joins two nodes with a thick line and a label.
+func ExampleFlowchart_ThickLinkWithText() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		ThickLinkWithText("A", "B", "always").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A == "always" ==> B
+}
+
+// ExampleFlowchart_InvisibleLink joins two nodes with a line that is not drawn,
+// which is how a diagram is pushed into the layout its author wants without
+// saying anything untrue about the flow.
+func ExampleFlowchart_InvisibleLink() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		InvisibleLink("A", "B").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A ~~~ B
+}
+
+// ExampleWithOrientalTopDown lays the flowchart out from the top downwards, which is the default.
+func ExampleWithOrientalTopDown() {
+	_ = flowchart.NewFlowchart(os.Stdout, flowchart.WithOrientalTopDown()).
+		NodeWithText("A", "Start").
+		Build()
+
+	// Output:
+	// flowchart TD
+	//     A["Start"]
+}
+
+// ExampleWithOrientalTopToBottom lays the flowchart out from the top to the
+// bottom. It is the same as WithOrientalTopDown under mermaid's other name for
+// it.
+func ExampleWithOrientalTopToBottom() {
+	_ = flowchart.NewFlowchart(os.Stdout, flowchart.WithOrientalTopToBottom()).
+		NodeWithText("A", "Start").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+}
+
+// ExampleWithOrientalBottomToTop lays the flowchart out from the bottom upwards.
+func ExampleWithOrientalBottomToTop() {
+	_ = flowchart.NewFlowchart(os.Stdout, flowchart.WithOrientalBottomToTop()).
+		NodeWithText("A", "Start").
+		Build()
+
+	// Output:
+	// flowchart BT
+	//     A["Start"]
+}
+
+// ExampleWithOrientalLeftToRight lays the flowchart out from the left to right.
+func ExampleWithOrientalLeftToRight() {
+	_ = flowchart.NewFlowchart(os.Stdout, flowchart.WithOrientalLeftToRight()).
+		NodeWithText("A", "Start").
+		Build()
+
+	// Output:
+	// flowchart LR
+	//     A["Start"]
+}
+
+// ExampleWithOrientalRightToLeft lays the flowchart out from the right to left.
+func ExampleWithOrientalRightToLeft() {
+	_ = flowchart.NewFlowchart(os.Stdout, flowchart.WithOrientalRightToLeft()).
+		NodeWithText("A", "Start").
+		Build()
+
+	// Output:
+	// flowchart RL
+	//     A["Start"]
+}
+
+// ExampleNewFlowchart shows the shape every flowchart has: a writer, a chain of
+// calls, and Build.
+func ExampleNewFlowchart() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("A", "Start").
+		NodeWithText("B", "End").
+		LinkWithArrowHead("A", "B").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["Start"]
+	//     B["End"]
+	//     A-->B
+}
+
+// ExampleFlowchart_Node declares a node by its identifier alone, for one whose
+// text is set by a later call or which needs none.
+func ExampleFlowchart_Node() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		Node("A").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A
+}
+
+// ExampleFlowchart_NodeWithMarkdown draws a node whose text is markdown, so it
+// can carry bold or a link.
+func ExampleFlowchart_NodeWithMarkdown() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithMarkdown("A", "**Start** here").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["`**Start** here`"]
+}
+
+// ExampleFlowchart_NodeWithNewLines draws a node whose text runs over several
+// lines. It is the same form as NodeWithMarkdown, which is what mermaid honors
+// a line break inside.
+func ExampleFlowchart_NodeWithNewLines() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithNewLines("A", "Start\nhere").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     A["`Start
+	// here`"]
+}
+
+// ExampleFlowchart_String returns the flowchart without needing a writer, which
+// is how it is handed to a markdown code block.
+func ExampleFlowchart_String() {
+	diagram := flowchart.NewFlowchart(io.Discard).
+		NodeWithText("A", "Start").
+		String()
+
+	_ = markdown.NewMarkdown(os.Stdout).
+		CodeBlocks(markdown.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// flowchart TB
+	//     A["Start"]
+	// ```
+}
+
+// ExampleFlowchart_Build writes the flowchart and reports the error the chain
+// recorded.
+func ExampleFlowchart_Build() {
+	err := flowchart.NewFlowchart(nil).NodeWithText("A", "Start").Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleWithTitle sets the title the flowchart is drawn with.
+func ExampleWithTitle() {
+	_ = flowchart.NewFlowchart(os.Stdout, flowchart.WithTitle("Checkout")).
+		NodeWithText("A", "Start").
+		Build()
+
+	// Output:
+	// ---
+	// title: "Checkout"
+	// ---
+	// flowchart TB
+	//     A["Start"]
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// flowchart is written, passed to NewFlowchart.
+func ExampleOption() {
+	options := []flowchart.Option{
+		flowchart.WithTitle("Checkout"),
+		flowchart.WithOrientalLeftToRight(),
+	}
+
+	_ = flowchart.NewFlowchart(os.Stdout, options...).
+		NodeWithText("A", "Start").
+		Build()
+
+	// Output:
+	// ---
+	// title: "Checkout"
+	// ---
+	// flowchart LR
+	//     A["Start"]
 }

--- a/mermaid/gantt/examples_test.go
+++ b/mermaid/gantt/examples_test.go
@@ -3,6 +3,8 @@
 package gantt_test
 
 import (
+	"fmt"
+	"io"
 	"os"
 
 	md "github.com/nao1215/markdown"
@@ -49,4 +51,492 @@ func ExampleChart() {
 	//     section Release
 	//     Launch :milestone, launch, 2024-01-26, 0d
 	// ```
+}
+
+// ExampleChart_Task adds a task that has not started.
+func ExampleChart_Task() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Design :2024-01-01, 10d
+}
+
+// ExampleChart_ActiveTask adds a task in progress, which mermaid draws hatched.
+func ExampleChart_ActiveTask() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		ActiveTask("Build", "2024-01-11", "20d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Build :active, 2024-01-11, 20d
+}
+
+// ExampleChart_DoneTask adds a task that is finished, which mermaid draws filled in.
+func ExampleChart_DoneTask() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		DoneTask("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Design :done, 2024-01-01, 10d
+}
+
+// ExampleChart_CriticalTask adds a task on the critical path, which mermaid draws in red.
+func ExampleChart_CriticalTask() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		CriticalTask("Sign the contract", "2024-01-01", "5d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Sign the contract :crit, 2024-01-01, 5d
+}
+
+// ExampleChart_CriticalActiveTask adds a critical task in progress.
+func ExampleChart_CriticalActiveTask() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		CriticalActiveTask("Migrate the data", "2024-01-06", "5d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Migrate the data :crit, active, 2024-01-06, 5d
+}
+
+// ExampleChart_CriticalDoneTask adds a critical task that is finished.
+func ExampleChart_CriticalDoneTask() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		CriticalDoneTask("Sign the contract", "2024-01-01", "5d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Sign the contract :crit, done, 2024-01-01, 5d
+}
+
+// ExampleChart_TaskWithID is Task with an identifier, which is what a later
+// task refers to when it says it starts after this one.
+func ExampleChart_TaskWithID() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		TaskWithID("Design", "design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Design :design, 2024-01-01, 10d
+}
+
+// ExampleChart_ActiveTaskWithID is ActiveTask with an identifier, which is what a later
+// task refers to when it says it starts after this one.
+func ExampleChart_ActiveTaskWithID() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		ActiveTaskWithID("Build", "build", "2024-01-11", "20d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Build :active, build, 2024-01-11, 20d
+}
+
+// ExampleChart_DoneTaskWithID is DoneTask with an identifier, which is what a later
+// task refers to when it says it starts after this one.
+func ExampleChart_DoneTaskWithID() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		DoneTaskWithID("Design", "design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Design :done, design, 2024-01-01, 10d
+}
+
+// ExampleChart_CriticalTaskWithID is CriticalTask with an identifier, which is what a later
+// task refers to when it says it starts after this one.
+func ExampleChart_CriticalTaskWithID() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		CriticalTaskWithID("Sign the contract", "sign", "2024-01-01", "5d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Sign the contract :crit, sign, 2024-01-01, 5d
+}
+
+// ExampleChart_CriticalActiveTaskWithID is CriticalActiveTask with an identifier, which is what a later
+// task refers to when it says it starts after this one.
+func ExampleChart_CriticalActiveTaskWithID() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		CriticalActiveTaskWithID("Migrate the data", "migrate", "2024-01-06", "5d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Migrate the data :crit, active, migrate, 2024-01-06, 5d
+}
+
+// ExampleChart_CriticalDoneTaskWithID is CriticalDoneTask with an identifier, which is what a later
+// task refers to when it says it starts after this one.
+func ExampleChart_CriticalDoneTaskWithID() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		CriticalDoneTaskWithID("Sign the contract", "sign", "2024-01-01", "5d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Sign the contract :crit, done, sign, 2024-01-01, 5d
+}
+
+// ExampleChart_MilestoneWithID is Milestone with an identifier, which is what a later
+// task refers to when it says it starts after this one.
+func ExampleChart_MilestoneWithID() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		MilestoneWithID("Launch", "launch", "2024-02-01").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Launch :milestone, launch, 2024-02-01, 0d
+}
+
+// ExampleChart_CriticalMilestoneWithID is CriticalMilestone with an identifier, which is what a later
+// task refers to when it says it starts after this one.
+func ExampleChart_CriticalMilestoneWithID() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		CriticalMilestoneWithID("Launch", "launch", "2024-02-01").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Launch :crit, milestone, launch, 2024-02-01, 0d
+}
+
+// ExampleNewChart shows the shape every gantt chart has: a writer, a chain of
+// calls, and Build.
+func ExampleNewChart() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Design :2024-01-01, 10d
+}
+
+// ExampleChart_Section groups the tasks that follow it into a band of the
+// chart.
+func ExampleChart_Section() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Design").
+		Task("Wireframes", "2024-01-01", "5d").
+		Section("Build").
+		Task("Implement", "2024-01-06", "20d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Design
+	//     Wireframes :2024-01-01, 5d
+	//     section Build
+	//     Implement :2024-01-06, 20d
+}
+
+// ExampleChart_Milestone marks a date rather than a span, so it is drawn as a
+// diamond with no width.
+func ExampleChart_Milestone() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		Milestone("Launch", "2024-02-01").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Launch :milestone, 2024-02-01, 0d
+}
+
+// ExampleChart_CriticalMilestone marks a date on the critical path.
+func ExampleChart_CriticalMilestone() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		CriticalMilestone("Contract expires", "2024-02-01").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Contract expires :crit, milestone, 2024-02-01, 0d
+}
+
+// ExampleChart_TaskAfter starts a task when another finishes rather than on a
+// date, so moving the first one moves everything behind it.
+func ExampleChart_TaskAfter() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		TaskWithID("Design", "design", "2024-01-01", "10d").
+		TaskAfter("Build", "design", "20d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Design :design, 2024-01-01, 10d
+	//     Build :after design, 20d
+}
+
+// ExampleChart_TaskAfterWithID starts a task after another and gives it an
+// identifier, so a third can be hung off it in turn.
+func ExampleChart_TaskAfterWithID() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		TaskWithID("Design", "design", "2024-01-01", "10d").
+		TaskAfterWithID("Build", "build", "design", "20d").
+		TaskAfter("Release", "build", "2d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Design :design, 2024-01-01, 10d
+	//     Build :build, after design, 20d
+	//     Release :after build, 2d
+}
+
+// ExampleChart_String returns the chart without needing a writer, which is how
+// it is handed to a markdown code block.
+func ExampleChart_String() {
+	chart := gantt.NewChart(io.Discard).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, chart).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// gantt
+	//     section Delivery
+	//     Design :2024-01-01, 10d
+	// ```
+}
+
+// ExampleChart_Build writes the chart and reports the error the chain recorded.
+func ExampleChart_Build() {
+	err := gantt.NewChart(nil).Section("Delivery").Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleChart_Error reports the same error Build does, for code that wants to
+// look before writing anything.
+func ExampleChart_Error() {
+	c := gantt.NewChart(io.Discard).Section("Delivery")
+	fmt.Println("error:", c.Error())
+
+	// Output:
+	// error: <nil>
+}
+
+// ExampleChart_LF adds a blank line to the chart body.
+func ExampleChart_LF() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Design").
+		Task("Wireframes", "2024-01-01", "5d").
+		LF().
+		Section("Build").
+		Task("Implement", "2024-01-06", "20d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Design
+	//     Wireframes :2024-01-01, 5d
+	//
+	//     section Build
+	//     Implement :2024-01-06, 20d
+}
+
+// ExampleWithTitle sets the title the chart is drawn with.
+func ExampleWithTitle() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithTitle("Release Plan")).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     title Release Plan
+	//     section Delivery
+	//     Design :2024-01-01, 10d
+}
+
+// ExampleWithDateFormat says how the dates in the chart are written. Without it
+// mermaid falls back to its own default, which is rarely the one the dates are
+// actually in.
+func ExampleWithDateFormat() {
+	_ = gantt.NewChart(os.Stdout, gantt.WithDateFormat("YYYY-MM-DD")).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Design :2024-01-01, 10d
+}
+
+// ExampleWithAxisFormat says how the dates along the bottom are drawn, which is
+// separate from how the dates in the chart are written.
+func ExampleWithAxisFormat() {
+	_ = gantt.NewChart(os.Stdout,
+		gantt.WithDateFormat("YYYY-MM-DD"),
+		gantt.WithAxisFormat("%d %b"),
+	).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     axisFormat %d %b
+	//     section Delivery
+	//     Design :2024-01-01, 10d
+}
+
+// ExampleWithTickInterval sets how often a mark appears along the bottom.
+func ExampleWithTickInterval() {
+	_ = gantt.NewChart(os.Stdout,
+		gantt.WithDateFormat("YYYY-MM-DD"),
+		gantt.WithTickInterval("1week"),
+	).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     tickInterval 1week
+	//     section Delivery
+	//     Design :2024-01-01, 10d
+}
+
+// ExampleWithTodayMarker styles the line marking today, or hides it outright
+// with "off", which is what a chart of a finished project wants.
+func ExampleWithTodayMarker() {
+	_ = gantt.NewChart(os.Stdout,
+		gantt.WithDateFormat("YYYY-MM-DD"),
+		gantt.WithTodayMarker("off"),
+	).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     todayMarker off
+	//     section Delivery
+	//     Design :2024-01-01, 10d
+}
+
+// ExampleWithExcludes leaves days out of the durations, so a ten day task that
+// skips weekends ends two weeks later rather than ten days later.
+func ExampleWithExcludes() {
+	_ = gantt.NewChart(os.Stdout,
+		gantt.WithDateFormat("YYYY-MM-DD"),
+		gantt.WithExcludes("weekends"),
+	).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     dateFormat YYYY-MM-DD
+	//     excludes weekends
+	//     section Delivery
+	//     Design :2024-01-01, 10d
+}
+
+// ExampleOption shows what an Option is: a function that changes how the chart
+// is written, passed to NewChart.
+func ExampleOption() {
+	options := []gantt.Option{
+		gantt.WithTitle("Release Plan"),
+		gantt.WithDateFormat("YYYY-MM-DD"),
+	}
+
+	_ = gantt.NewChart(os.Stdout, options...).
+		Section("Delivery").
+		Task("Design", "2024-01-01", "10d").
+		Build()
+
+	// Output:
+	// gantt
+	//     title Release Plan
+	//     dateFormat YYYY-MM-DD
+	//     section Delivery
+	//     Design :2024-01-01, 10d
 }

--- a/mermaid/gitgraph/examples_test.go
+++ b/mermaid/gitgraph/examples_test.go
@@ -3,6 +3,7 @@
 package gitgraph_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -46,4 +47,368 @@ func ExampleDiagram() {
 	//     checkout main
 	//     merge develop tag: "v1.0.0"
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every git graph has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := gitgraph.NewDiagram(io.Discard).
+		Commit(gitgraph.WithCommitID("initial")).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// gitGraph
+	//     commit id: "initial"
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := gitgraph.NewDiagram(nil).
+		Commit(gitgraph.WithCommitID("initial")).
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := gitgraph.NewDiagram(io.Discard).
+		Checkout("never-branched")
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: <nil>
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		LF().
+		Commit(gitgraph.WithCommitID("initial")).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//
+	//     commit id: "initial"
+}
+
+// ExampleDiagram_full shows a git graph built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := gitgraph.NewDiagram(io.Discard).
+		Commit(gitgraph.WithCommitID("initial")).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// gitGraph
+	//     commit id: "initial"
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []gitgraph.Option{gitgraph.WithTitle("Overview")}
+
+	_ = gitgraph.NewDiagram(os.Stdout, options...).
+		Commit(gitgraph.WithCommitID("initial")).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// gitGraph
+	//     commit id: "initial"
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = gitgraph.NewDiagram(os.Stdout, gitgraph.WithTitle("Overview")).
+		Commit(gitgraph.WithCommitID("initial")).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// gitGraph
+	//     commit id: "initial"
+}
+
+// ExampleDiagram_Commit adds a commit to the current branch.
+func ExampleDiagram_Commit() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit().
+		Commit(gitgraph.WithCommitID("second")).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit
+	//     commit id: "second"
+}
+
+// ExampleDiagram_Branch starts a branch and switches to it, so the commits that
+// follow belong to it.
+func ExampleDiagram_Branch() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Branch("develop").
+		Commit(gitgraph.WithCommitID("work")).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//     branch develop
+	//     commit id: "work"
+}
+
+// ExampleDiagram_Checkout switches back to a branch that already exists.
+func ExampleDiagram_Checkout() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Branch("develop").
+		Commit(gitgraph.WithCommitID("work")).
+		Checkout("main").
+		Commit(gitgraph.WithCommitID("hotfix")).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//     branch develop
+	//     commit id: "work"
+	//     checkout main
+	//     commit id: "hotfix"
+}
+
+// ExampleDiagram_Merge brings a branch back into the current one. It takes the
+// commit options, because a merge is drawn as a commit and can carry a tag.
+func ExampleDiagram_Merge() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Branch("develop").
+		Commit(gitgraph.WithCommitID("work")).
+		Checkout("main").
+		Merge("develop", gitgraph.WithCommitTag("v1.0.0")).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//     branch develop
+	//     commit id: "work"
+	//     checkout main
+	//     merge develop tag: "v1.0.0"
+}
+
+// ExampleDiagram_CherryPick copies one commit onto the current branch. The
+// commit it names has to exist already.
+func ExampleDiagram_CherryPick() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Branch("develop").
+		Commit(gitgraph.WithCommitID("fix")).
+		Checkout("main").
+		CherryPick("fix").
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//     branch develop
+	//     commit id: "fix"
+	//     checkout main
+	//     cherry-pick id: "fix"
+}
+
+// ExampleDiagram_Reset moves the current branch back to a commit.
+func ExampleDiagram_Reset() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Commit(gitgraph.WithCommitID("mistake")).
+		Reset("initial").
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//     commit id: "mistake"
+	//     reset id: "initial"
+}
+
+// ExampleWithCommitID names a commit, which is what a cherry pick and a reset
+// refer to.
+func ExampleWithCommitID() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+}
+
+// ExampleWithCommitTag puts a tag on a commit, drawn beside it.
+func ExampleWithCommitTag() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("release"), gitgraph.WithCommitTag("v1.0.0")).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "release" tag: "v1.0.0"
+}
+
+// ExampleWithCommitType changes the shape a commit is drawn as.
+func ExampleWithCommitType() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitType(gitgraph.CommitTypeHighlight)).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit type: HIGHLIGHT
+}
+
+// ExampleCommitType shows the three shapes a commit can be drawn as.
+func ExampleCommitType() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("a"), gitgraph.WithCommitType(gitgraph.CommitTypeNormal)).
+		Commit(gitgraph.WithCommitID("b"), gitgraph.WithCommitType(gitgraph.CommitTypeReverse)).
+		Commit(gitgraph.WithCommitID("c"), gitgraph.WithCommitType(gitgraph.CommitTypeHighlight)).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "a" type: NORMAL
+	//     commit id: "b" type: REVERSE
+	//     commit id: "c" type: HIGHLIGHT
+}
+
+// ExampleWithBranchOrder says where a branch is drawn against the others, which
+// is how a diagram keeps the important branch at the top.
+func ExampleWithBranchOrder() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Branch("release", gitgraph.WithBranchOrder(1)).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//     branch release order: 1
+}
+
+// ExampleWithCherryPickParent says which parent of a merge commit a cherry pick
+// takes, which mermaid needs when the commit being picked is a merge.
+func ExampleWithCherryPickParent() {
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Branch("develop").
+		Commit(gitgraph.WithCommitID("work")).
+		Checkout("main").
+		Merge("develop", gitgraph.WithCommitID("merge")).
+		Branch("release").
+		CherryPick("merge", gitgraph.WithCherryPickParent("initial")).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//     branch develop
+	//     commit id: "work"
+	//     checkout main
+	//     merge develop id: "merge"
+	//     branch release
+	//     cherry-pick id: "merge" parent: "initial"
+}
+
+// ExampleCommitOption shows what a CommitOption is: a function that changes how
+// a commit is written, passed to Commit or to Merge.
+func ExampleCommitOption() {
+	options := []gitgraph.CommitOption{
+		gitgraph.WithCommitID("release"),
+		gitgraph.WithCommitTag("v1.0.0"),
+	}
+
+	_ = gitgraph.NewDiagram(os.Stdout).Commit(options...).Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "release" tag: "v1.0.0"
+}
+
+// ExampleBranchOption shows what a BranchOption is: a function that changes how
+// a branch is written, passed to Branch after its name.
+func ExampleBranchOption() {
+	options := []gitgraph.BranchOption{gitgraph.WithBranchOrder(2)}
+
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Branch("release", options...).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//     branch release order: 2
+}
+
+// ExampleCherryPickOption shows what a CherryPickOption is: a function that
+// changes how a cherry pick is written, passed to CherryPick after the commit
+// it names.
+func ExampleCherryPickOption() {
+	options := []gitgraph.CherryPickOption{}
+
+	_ = gitgraph.NewDiagram(os.Stdout).
+		Commit(gitgraph.WithCommitID("initial")).
+		Branch("develop").
+		Commit(gitgraph.WithCommitID("fix")).
+		Checkout("main").
+		CherryPick("fix", options...).
+		Build()
+
+	// Output:
+	// gitGraph
+	//     commit id: "initial"
+	//     branch develop
+	//     commit id: "fix"
+	//     checkout main
+	//     cherry-pick id: "fix"
 }

--- a/mermaid/kanban/examples_test.go
+++ b/mermaid/kanban/examples_test.go
@@ -3,6 +3,7 @@
 package kanban_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -53,4 +54,329 @@ func ExampleDiagram() {
 	//     [In Progress]
 	//         [Review API]@{ priority: 'Very High' }
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every kanban board has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").Task("Write the spec").
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//         [Write the spec]
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := kanban.NewDiagram(io.Discard).
+		Column("Todo").Task("Write the spec").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// kanban
+	//     [Todo]
+	//         [Write the spec]
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := kanban.NewDiagram(nil).
+		Column("Todo").Task("Write the spec").
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := kanban.NewDiagram(io.Discard).
+		Task("no column yet")
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: task "no column yet" requires a column; call Column first
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").Task("Write the spec").
+		LF().
+		Column("Todo").Task("Write the spec").
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//         [Write the spec]
+	//
+	//     [Todo]
+	//         [Write the spec]
+}
+
+// ExampleDiagram_full shows a kanban board built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := kanban.NewDiagram(io.Discard).
+		Column("Todo").Task("Write the spec").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// kanban
+	//     [Todo]
+	//         [Write the spec]
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []kanban.Option{kanban.WithTitle("Overview")}
+
+	_ = kanban.NewDiagram(os.Stdout, options...).
+		Column("Todo").Task("Write the spec").
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// kanban
+	//     [Todo]
+	//         [Write the spec]
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = kanban.NewDiagram(os.Stdout, kanban.WithTitle("Overview")).
+		Column("Todo").Task("Write the spec").
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// kanban
+	//     [Todo]
+	//         [Write the spec]
+}
+
+// ExampleDiagram_Column adds a column, and the tasks that follow belong to it.
+// A board needs one before any task, and a task added without one is reported
+// from Build.
+func ExampleDiagram_Column() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").
+		Task("Write the spec").
+		Column("Done").
+		Task("Read the spec").
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//         [Write the spec]
+	//     [Done]
+	//         [Read the spec]
+}
+
+// ExampleDiagram_Task adds a card to the current column.
+func ExampleDiagram_Task() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").
+		Task("Write the spec").
+		Task("Review the spec").
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//         [Write the spec]
+	//         [Review the spec]
+}
+
+// ExampleDiagram_TaskIn adds a card to a column named outright, which saves
+// switching back and forth when the cards of two columns are interleaved in the
+// calling code.
+func ExampleDiagram_TaskIn() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").
+		Column("Done").
+		TaskIn("Todo", "Write the spec").
+		TaskIn("Done", "Read the spec").
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//     [Done]
+	//     [Todo]
+	//         [Write the spec]
+	//     [Done]
+	//         [Read the spec]
+}
+
+// ExampleWithColumnID gives a column an identifier of its own, which is what
+// TaskIn and a link from outside the board refer to.
+func ExampleWithColumnID() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo", kanban.WithColumnID("todo")).
+		Task("Write the spec").
+		Build()
+
+	// Output:
+	// kanban
+	//     todo[Todo]
+	//         [Write the spec]
+}
+
+// ExampleWithTaskID gives a card an identifier of its own.
+func ExampleWithTaskID() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").
+		Task("Write the spec", kanban.WithTaskID("kb-1")).
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//         kb-1[Write the spec]
+}
+
+// ExampleWithTaskTicket puts a ticket reference on a card. With
+// WithTicketBaseURL on the board, mermaid draws it as a link.
+func ExampleWithTaskTicket() {
+	_ = kanban.NewDiagram(os.Stdout, kanban.WithTicketBaseURL("https://example.com/browse/")).
+		Column("Todo").
+		Task("Write the spec", kanban.WithTaskTicket("KB-1")).
+		Build()
+
+	// Output:
+	// ---
+	// config:
+	//   kanban:
+	//     ticketBaseUrl: 'https://example.com/browse/'
+	// ---
+	// kanban
+	//     [Todo]
+	//         [Write the spec]@{ ticket: 'KB-1' }
+}
+
+// ExampleWithTaskAssigned puts a name on a card.
+func ExampleWithTaskAssigned() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").
+		Task("Write the spec", kanban.WithTaskAssigned("Alice")).
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//         [Write the spec]@{ assigned: 'Alice' }
+}
+
+// ExampleWithTaskPriority puts a priority on a card, which mermaid draws as a
+// colored stripe down its side.
+func ExampleWithTaskPriority() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").
+		Task("Write the spec", kanban.WithTaskPriority(kanban.PriorityVeryHigh)).
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//         [Write the spec]@{ priority: 'Very High' }
+}
+
+// ExamplePriority shows the four priorities a card can carry.
+func ExamplePriority() {
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").
+		Task("Lowest", kanban.WithTaskPriority(kanban.PriorityVeryLow)).
+		Task("Low", kanban.WithTaskPriority(kanban.PriorityLow)).
+		Task("High", kanban.WithTaskPriority(kanban.PriorityHigh)).
+		Task("Highest", kanban.WithTaskPriority(kanban.PriorityVeryHigh)).
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//         [Lowest]@{ priority: 'Very Low' }
+	//         [Low]@{ priority: 'Low' }
+	//         [High]@{ priority: 'High' }
+	//         [Highest]@{ priority: 'Very High' }
+}
+
+// ExampleWithTicketBaseURL sets what a card's ticket reference is prefixed with,
+// which is what turns "KB-1" into a link a reader can follow.
+func ExampleWithTicketBaseURL() {
+	_ = kanban.NewDiagram(os.Stdout, kanban.WithTicketBaseURL("https://example.com/browse/")).
+		Column("Todo").
+		Task("Write the spec", kanban.WithTaskTicket("KB-1")).
+		Build()
+
+	// Output:
+	// ---
+	// config:
+	//   kanban:
+	//     ticketBaseUrl: 'https://example.com/browse/'
+	// ---
+	// kanban
+	//     [Todo]
+	//         [Write the spec]@{ ticket: 'KB-1' }
+}
+
+// ExampleColumnOption shows what a ColumnOption is: a function that changes how
+// a column is written, passed to Column after its name.
+func ExampleColumnOption() {
+	options := []kanban.ColumnOption{kanban.WithColumnID("todo")}
+
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo", options...).
+		Task("Write the spec").
+		Build()
+
+	// Output:
+	// kanban
+	//     todo[Todo]
+	//         [Write the spec]
+}
+
+// ExampleTaskOption shows what a TaskOption is: a function that changes how a
+// card is written, passed to Task after its name.
+func ExampleTaskOption() {
+	options := []kanban.TaskOption{kanban.WithTaskID("kb-1"), kanban.WithTaskAssigned("Alice")}
+
+	_ = kanban.NewDiagram(os.Stdout).
+		Column("Todo").
+		Task("Write the spec", options...).
+		Build()
+
+	// Output:
+	// kanban
+	//     [Todo]
+	//         kb-1[Write the spec]@{ assigned: 'Alice' }
 }

--- a/mermaid/mindmap/examples_test.go
+++ b/mermaid/mindmap/examples_test.go
@@ -111,12 +111,18 @@ func ExampleDiagram_Error() {
 // ExampleDiagram_LF adds a blank line to the diagram body.
 func ExampleDiagram_LF() {
 	_ = mindmap.NewDiagram(os.Stdout).
-		Root("Product").Child("Market").
+		Root("Product").
+		Child("Market").
 		LF().
-		Root("Product").Child("Market").
+		Sibling("Engineering").
 		Build()
 
 	// Output:
+	// mindmap
+	//     Product
+	//         Market
+	//
+	//         Engineering
 }
 
 // ExampleDiagram_full shows a mindmap built end to end and put into a markdown

--- a/mermaid/mindmap/examples_test.go
+++ b/mermaid/mindmap/examples_test.go
@@ -3,6 +3,7 @@
 package mindmap_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -49,4 +50,210 @@ func ExampleDiagram() {
 	//             Q1
 	//             Q2
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every mindmap has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = mindmap.NewDiagram(os.Stdout).
+		Root("Product").Child("Market").
+		Build()
+
+	// Output:
+	// mindmap
+	//     Product
+	//         Market
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := mindmap.NewDiagram(io.Discard).
+		Root("Product").Child("Market").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// mindmap
+	//     Product
+	//         Market
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := mindmap.NewDiagram(nil).
+		Root("Product").Child("Market").
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := mindmap.NewDiagram(io.Discard).
+		Child("a child with no root")
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: root node must be defined first
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = mindmap.NewDiagram(os.Stdout).
+		Root("Product").Child("Market").
+		LF().
+		Root("Product").Child("Market").
+		Build()
+
+	// Output:
+}
+
+// ExampleDiagram_full shows a mindmap built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := mindmap.NewDiagram(io.Discard).
+		Root("Product").Child("Market").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// mindmap
+	//     Product
+	//         Market
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []mindmap.Option{mindmap.WithTitle("Overview")}
+
+	_ = mindmap.NewDiagram(os.Stdout, options...).
+		Root("Product").Child("Market").
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// mindmap
+	//     Product
+	//         Market
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = mindmap.NewDiagram(os.Stdout, mindmap.WithTitle("Overview")).
+		Root("Product").Child("Market").
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// mindmap
+	//     Product
+	//         Market
+}
+
+// ExampleDiagram_Root adds the node everything else hangs from. A mindmap needs
+// one before anything else, and a child added without it is reported from Build
+// rather than drawn at the top level.
+func ExampleDiagram_Root() {
+	_ = mindmap.NewDiagram(os.Stdout).
+		Root("Product").
+		Child("Market").
+		Build()
+
+	// Output:
+	// mindmap
+	//     Product
+	//         Market
+}
+
+// ExampleDiagram_Child adds a node one level below the current one and descends
+// into it, so a second Child is a grandchild of the first.
+func ExampleDiagram_Child() {
+	_ = mindmap.NewDiagram(os.Stdout).
+		Root("Product").
+		Child("Market").
+		Child("Segments").
+		Build()
+
+	// Output:
+	// mindmap
+	//     Product
+	//         Market
+	//             Segments
+}
+
+// ExampleDiagram_Sibling adds a node beside the current one rather than under
+// it, which is how a level gains a second entry.
+func ExampleDiagram_Sibling() {
+	_ = mindmap.NewDiagram(os.Stdout).
+		Root("Product").
+		Child("Market").
+		Sibling("Engineering").
+		Build()
+
+	// Output:
+	// mindmap
+	//     Product
+	//         Market
+	//         Engineering
+}
+
+// ExampleDiagram_Parent moves back up a level, so what follows is a sibling of
+// the node above rather than of the current one.
+func ExampleDiagram_Parent() {
+	_ = mindmap.NewDiagram(os.Stdout).
+		Root("Product").
+		Child("Market").
+		Child("Segments").
+		Parent().
+		Sibling("Pricing").
+		Build()
+
+	// Output:
+	// mindmap
+	//     Product
+	//         Market
+	//             Segments
+	//         Pricing
+}
+
+// ExampleDiagram_Node puts a node at a level named outright, for a tree that is
+// walked rather than written by hand. The root is level 0, and a level more
+// than one deeper than the last is reported rather than drawn.
+func ExampleDiagram_Node() {
+	_ = mindmap.NewDiagram(os.Stdout).
+		Node(0, "Product").
+		Node(1, "Market").
+		Node(2, "Segments").
+		Node(1, "Engineering").
+		Build()
+
+	// Output:
+	// mindmap
+	//     Product
+	//         Market
+	//             Segments
+	//         Engineering
 }

--- a/mermaid/packet/examples_test.go
+++ b/mermaid/packet/examples_test.go
@@ -3,6 +3,7 @@
 package packet_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -42,4 +43,163 @@ func ExampleDiagram() {
 	//     48-63: "Checksum"
 	//     64-95: "Data (variable length)"
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every packet diagram has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = packet.NewDiagram(os.Stdout).
+		Field(0, 15, "Source Port").
+		Build()
+
+	// Output:
+	// packet
+	//     0-15: "Source Port"
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := packet.NewDiagram(io.Discard).
+		Field(0, 15, "Source Port").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// packet
+	//     0-15: "Source Port"
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := packet.NewDiagram(nil).
+		Field(0, 15, "Source Port").
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := packet.NewDiagram(io.Discard).
+		Field(15, 0, "Backwards")
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: start bit must be less than or equal to end bit
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = packet.NewDiagram(os.Stdout).
+		Field(0, 15, "Source Port").
+		LF().
+		Field(0, 15, "Source Port").
+		Build()
+
+	// Output:
+	// packet
+	//     0-15: "Source Port"
+	//
+	//     0-15: "Source Port"
+}
+
+// ExampleDiagram_full shows a packet diagram built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := packet.NewDiagram(io.Discard).
+		Field(0, 15, "Source Port").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// packet
+	//     0-15: "Source Port"
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []packet.Option{packet.WithTitle("Overview")}
+
+	_ = packet.NewDiagram(os.Stdout, options...).
+		Field(0, 15, "Source Port").
+		Build()
+
+	// Output:
+	// packet
+	//     title Overview
+	//     0-15: "Source Port"
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = packet.NewDiagram(os.Stdout, packet.WithTitle("Overview")).
+		Field(0, 15, "Source Port").
+		Build()
+
+	// Output:
+	// packet
+	//     title Overview
+	//     0-15: "Source Port"
+}
+
+// ExampleDiagram_Field adds a field spanning a range of bits. The range is
+// inclusive at both ends, so a sixteen bit field runs from 0 to 15.
+func ExampleDiagram_Field() {
+	_ = packet.NewDiagram(os.Stdout).
+		Field(0, 15, "Source Port").
+		Field(16, 31, "Destination Port").
+		Build()
+
+	// Output:
+	// packet
+	//     0-15: "Source Port"
+	//     16-31: "Destination Port"
+}
+
+// ExampleDiagram_Bit adds a field one bit wide, which is what a flag is.
+func ExampleDiagram_Bit() {
+	_ = packet.NewDiagram(os.Stdout).
+		Bit(0, "SYN").
+		Bit(1, "ACK").
+		Build()
+
+	// Output:
+	// packet
+	//     0: "SYN"
+	//     1: "ACK"
+}
+
+// ExampleDiagram_Next adds a field by its width rather than its position, so a
+// packet can be described without counting the bits that came before it.
+func ExampleDiagram_Next() {
+	_ = packet.NewDiagram(os.Stdout).
+		Next(16, "Source Port").
+		Next(16, "Destination Port").
+		Next(32, "Sequence Number").
+		Build()
+
+	// Output:
+	// packet
+	//     +16: "Source Port"
+	//     +16: "Destination Port"
+	//     +32: "Sequence Number"
 }

--- a/mermaid/piechart/examples_test.go
+++ b/mermaid/piechart/examples_test.go
@@ -3,6 +3,8 @@
 package piechart_test
 
 import (
+	"fmt"
+	"io"
 	"os"
 
 	md "github.com/nao1215/markdown"
@@ -39,4 +41,135 @@ func ExamplePieChart() {
 	//     "B" : 20.100000
 	//     "C" : 30
 	// ```
+}
+
+// ExampleNewPieChart shows the shape every pie chart has: a writer, a chain of
+// calls, and Build.
+func ExampleNewPieChart() {
+	_ = piechart.NewPieChart(os.Stdout).
+		LabelAndIntValue("Go", 60).
+		LabelAndIntValue("Rust", 40).
+		Build()
+
+	// Output:
+	// %%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+	// pie
+	//     "Go" : 60
+	//     "Rust" : 40
+}
+
+// ExamplePieChart_LabelAndIntValue adds a slice with a whole number.
+func ExamplePieChart_LabelAndIntValue() {
+	_ = piechart.NewPieChart(os.Stdout).
+		LabelAndIntValue("Go", 60).
+		LabelAndIntValue("Rust", 40).
+		Build()
+
+	// Output:
+	// %%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+	// pie
+	//     "Go" : 60
+	//     "Rust" : 40
+}
+
+// ExamplePieChart_LabelAndFloatValue adds a slice with a fractional value. It
+// is written with six digits after the point, whatever the value.
+func ExamplePieChart_LabelAndFloatValue() {
+	_ = piechart.NewPieChart(os.Stdout).
+		LabelAndFloatValue("Go", 60.5).
+		LabelAndFloatValue("Rust", 39.5).
+		Build()
+
+	// Output:
+	// %%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+	// pie
+	//     "Go" : 60.500000
+	//     "Rust" : 39.500000
+}
+
+// ExamplePieChart_String returns the chart without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExamplePieChart_String() {
+	chart := piechart.NewPieChart(io.Discard).
+		LabelAndIntValue("Go", 60).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, chart).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// %%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+	// pie
+	//     "Go" : 60
+	// ```
+}
+
+// ExamplePieChart_Build writes the chart and reports the error the chain
+// recorded.
+func ExamplePieChart_Build() {
+	err := piechart.NewPieChart(nil).LabelAndIntValue("Go", 60).Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleWithTitle sets the title the chart is drawn with.
+func ExampleWithTitle() {
+	_ = piechart.NewPieChart(os.Stdout, piechart.WithTitle("Languages")).
+		LabelAndIntValue("Go", 60).
+		Build()
+
+	// Output:
+	// %%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+	// pie
+	//     title Languages
+	//     "Go" : 60
+}
+
+// ExampleWithShowData draws each slice's value beside its label, which is the
+// difference between a chart a reader can read numbers off and one they cannot.
+func ExampleWithShowData() {
+	_ = piechart.NewPieChart(os.Stdout, piechart.WithShowData(true)).
+		LabelAndIntValue("Go", 60).
+		LabelAndIntValue("Rust", 40).
+		Build()
+
+	// Output:
+	// %%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+	// pie showData
+	//     "Go" : 60
+	//     "Rust" : 40
+}
+
+// ExampleWithTextPosition moves the labels between the center of the chart and
+// its outer edge. It takes 0.0 to 1.0, and anything outside that is ignored in
+// favor of the default.
+func ExampleWithTextPosition() {
+	_ = piechart.NewPieChart(os.Stdout, piechart.WithTextPosition(0.4)).
+		LabelAndIntValue("Go", 60).
+		Build()
+
+	// Output:
+	// %%{init: {"pie": {"textPosition": 0.40}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+	// pie
+	//     "Go" : 60
+}
+
+// ExampleOption shows what an Option is: a function that changes how the chart
+// is written, passed to NewPieChart.
+func ExampleOption() {
+	options := []piechart.Option{piechart.WithTitle("Languages"), piechart.WithShowData(true)}
+
+	_ = piechart.NewPieChart(os.Stdout, options...).
+		LabelAndIntValue("Go", 60).
+		Build()
+
+	// Output:
+	// %%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+	// pie showData
+	//     title Languages
+	//     "Go" : 60
 }

--- a/mermaid/quadrant/examples_test.go
+++ b/mermaid/quadrant/examples_test.go
@@ -3,6 +3,8 @@
 package quadrant_test
 
 import (
+	"fmt"
+	"io"
 	"os"
 
 	md "github.com/nao1215/markdown"
@@ -101,4 +103,312 @@ func ExampleChart_withStyling() {
 	//     classDef class1 color: #109060
 	//     classDef class2 color: #908342, radius: 10, stroke-color: #310085, stroke-width: 10px
 	// ```
+}
+
+// ExampleNewChart shows the shape every quadrant chart has: a writer, the axes,
+// the quadrant labels, the points, and Build.
+func ExampleNewChart() {
+	_ = quadrant.NewChart(os.Stdout, quadrant.WithTitle("Reach and Engagement")).
+		XAxis("Low Reach", "High Reach").
+		YAxis("Low Engagement", "High Engagement").
+		Quadrant1("We should expand").
+		Quadrant2("Need to promote").
+		Quadrant3("Re-evaluate").
+		Quadrant4("May be improved").
+		Point("Campaign A", 0.3, 0.6).
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     title Reach and Engagement
+	//     x-axis Low Reach --> High Reach
+	//     y-axis Low Engagement --> High Engagement
+	//     quadrant-1 We should expand
+	//     quadrant-2 Need to promote
+	//     quadrant-3 Re-evaluate
+	//     quadrant-4 May be improved
+	//     Campaign A: [0.30, 0.60]
+}
+
+// ExampleChart_XAxis names the two ends of the horizontal axis. Passing one
+// label names the axis itself instead.
+func ExampleChart_XAxis() {
+	_ = quadrant.NewChart(os.Stdout).
+		XAxis("Low Reach", "High Reach").
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     x-axis Low Reach --> High Reach
+}
+
+// ExampleChart_YAxis names the two ends of the vertical axis.
+func ExampleChart_YAxis() {
+	_ = quadrant.NewChart(os.Stdout).
+		YAxis("Low Engagement", "High Engagement").
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     y-axis Low Engagement --> High Engagement
+}
+
+// ExampleChart_Quadrant1 names the top right quadrant.
+func ExampleChart_Quadrant1() {
+	_ = quadrant.NewChart(os.Stdout).Quadrant1("We should expand").Build()
+
+	// Output:
+	// quadrantChart
+	//     quadrant-1 We should expand
+}
+
+// ExampleChart_Quadrant2 names the top left quadrant.
+func ExampleChart_Quadrant2() {
+	_ = quadrant.NewChart(os.Stdout).Quadrant2("Need to promote").Build()
+
+	// Output:
+	// quadrantChart
+	//     quadrant-2 Need to promote
+}
+
+// ExampleChart_Quadrant3 names the bottom left quadrant.
+func ExampleChart_Quadrant3() {
+	_ = quadrant.NewChart(os.Stdout).Quadrant3("Re-evaluate").Build()
+
+	// Output:
+	// quadrantChart
+	//     quadrant-3 Re-evaluate
+}
+
+// ExampleChart_Quadrant4 names the bottom right quadrant.
+func ExampleChart_Quadrant4() {
+	_ = quadrant.NewChart(os.Stdout).Quadrant4("May be improved").Build()
+
+	// Output:
+	// quadrantChart
+	//     quadrant-4 May be improved
+}
+
+// ExampleChart_Point places one thing on the chart. Both coordinates run from
+// 0.0 to 1.0, and they are written with two digits after the point.
+func ExampleChart_Point() {
+	_ = quadrant.NewChart(os.Stdout).
+		Point("Campaign A", 0.3, 0.6).
+		Point("Campaign B", 0.45, 0.23).
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     Campaign A: [0.30, 0.60]
+	//     Campaign B: [0.45, 0.23]
+}
+
+// ExampleChart_PointWithStyle places a point and styles it with a string
+// mermaid reads directly.
+func ExampleChart_PointWithStyle() {
+	_ = quadrant.NewChart(os.Stdout).
+		PointWithStyle("Campaign A", 0.3, 0.6, "radius: 10, color: #ff0000").
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     Campaign A: [0.30, 0.60] radius: 10, color: #ff0000
+}
+
+// ExampleChart_PointStyled places a point and styles it with a struct, so the
+// caller does not have to build the string mermaid wants.
+func ExampleChart_PointStyled() {
+	_ = quadrant.NewChart(os.Stdout).
+		PointStyled("Campaign A", 0.3, 0.6, quadrant.PointStyle{
+			Color:       "#ff0000",
+			Radius:      10,
+			StrokeColor: "#000000",
+			StrokeWidth: "2px",
+		}).
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     Campaign A: [0.30, 0.60] color: #ff0000, radius: 10, stroke-color: #000000, stroke-width: 2px
+}
+
+// ExampleChart_PointWithClass places a point styled by a class, which is how
+// several points share one style.
+func ExampleChart_PointWithClass() {
+	_ = quadrant.NewChart(os.Stdout).
+		ClassDef("winner", "color: #00ff00").
+		PointWithClass("Campaign A", 0.3, 0.6, "winner").
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     classDef winner color: #00ff00
+	//     Campaign A:::winner: [0.30, 0.60]
+}
+
+// ExampleChart_PointWithClassAndStyle places a point styled by a class and then
+// adjusted, for the one point that should stand out among its peers.
+func ExampleChart_PointWithClassAndStyle() {
+	_ = quadrant.NewChart(os.Stdout).
+		ClassDef("winner", "color: #00ff00").
+		PointWithClassAndStyle("Campaign A", 0.3, 0.6, "winner", "radius: 12").
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     classDef winner color: #00ff00
+	//     Campaign A:::winner: [0.30, 0.60] radius: 12
+}
+
+// ExampleChart_ClassDef names a style so several points can share it.
+func ExampleChart_ClassDef() {
+	_ = quadrant.NewChart(os.Stdout).
+		ClassDef("winner", "color: #00ff00, radius: 10").
+		PointWithClass("Campaign A", 0.3, 0.6, "winner").
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     classDef winner color: #00ff00, radius: 10
+	//     Campaign A:::winner: [0.30, 0.60]
+}
+
+// ExampleChart_ClassDefStyled names a style described by a struct rather than a
+// string.
+func ExampleChart_ClassDefStyled() {
+	_ = quadrant.NewChart(os.Stdout).
+		ClassDefStyled("winner", quadrant.ClassStyle{Color: "#00ff00", Radius: 10}).
+		PointWithClass("Campaign A", 0.3, 0.6, "winner").
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     classDef winner color: #00ff00, radius: 10
+	//     Campaign A:::winner: [0.30, 0.60]
+}
+
+// ExampleChart_String returns the chart without needing a writer, which is how
+// it is handed to a markdown code block.
+func ExampleChart_String() {
+	chart := quadrant.NewChart(io.Discard).Point("Campaign A", 0.3, 0.6).String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, chart).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// quadrantChart
+	//     Campaign A: [0.30, 0.60]
+	// ```
+}
+
+// ExampleChart_Build writes the chart and reports the error the chain recorded.
+func ExampleChart_Build() {
+	err := quadrant.NewChart(nil).Point("Campaign A", 0.3, 0.6).Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleChart_Error reports the same error Build does, for code that wants to
+// look before writing anything.
+func ExampleChart_Error() {
+	ch := quadrant.NewChart(io.Discard).Point("Campaign A", 0.3, 0.6)
+	fmt.Println("error:", ch.Error())
+
+	// Output:
+	// error: <nil>
+}
+
+// ExampleChart_LF adds a blank line to the chart body.
+func ExampleChart_LF() {
+	_ = quadrant.NewChart(os.Stdout).
+		Point("Campaign A", 0.3, 0.6).
+		LF().
+		Point("Campaign B", 0.45, 0.23).
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     Campaign A: [0.30, 0.60]
+	//
+	//     Campaign B: [0.45, 0.23]
+}
+
+// ExamplePointStyle shows how one point is styled. Every field is optional, and
+// the zero value of one leaves mermaid's default alone.
+func ExamplePointStyle() {
+	style := quadrant.PointStyle{Color: "#ff0000", Radius: 10}
+
+	_ = quadrant.NewChart(os.Stdout).
+		PointStyled("Campaign A", 0.3, 0.6, style).
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     Campaign A: [0.30, 0.60] color: #ff0000, radius: 10
+}
+
+// ExamplePointStyle_String renders the style as the string mermaid reads, which
+// is what PointStyled writes for you.
+func ExamplePointStyle_String() {
+	style := quadrant.PointStyle{Color: "#ff0000", Radius: 10, StrokeWidth: "2px"}
+	fmt.Println(style.String())
+
+	// Output:
+	// color: #ff0000, radius: 10, stroke-width: 2px
+}
+
+// ExampleClassStyle shows how a named style is described.
+func ExampleClassStyle() {
+	style := quadrant.ClassStyle{Color: "#00ff00", Radius: 10}
+
+	_ = quadrant.NewChart(os.Stdout).
+		ClassDefStyled("winner", style).
+		PointWithClass("Campaign A", 0.3, 0.6, "winner").
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     classDef winner color: #00ff00, radius: 10
+	//     Campaign A:::winner: [0.30, 0.60]
+}
+
+// ExampleClassStyle_String renders the style as the string mermaid reads, which
+// is what ClassDefStyled writes for you.
+func ExampleClassStyle_String() {
+	style := quadrant.ClassStyle{Color: "#00ff00", Radius: 10}
+	fmt.Println(style.String())
+
+	// Output:
+	// color: #00ff00, radius: 10
+}
+
+// ExampleWithTitle sets the title the chart is drawn with.
+func ExampleWithTitle() {
+	_ = quadrant.NewChart(os.Stdout, quadrant.WithTitle("Reach and Engagement")).
+		Point("Campaign A", 0.3, 0.6).
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     title Reach and Engagement
+	//     Campaign A: [0.30, 0.60]
+}
+
+// ExampleOption shows what an Option is: a function that changes how the chart
+// is written, passed to NewChart.
+func ExampleOption() {
+	options := []quadrant.Option{quadrant.WithTitle("Reach and Engagement")}
+
+	_ = quadrant.NewChart(os.Stdout, options...).
+		Point("Campaign A", 0.3, 0.6).
+		Build()
+
+	// Output:
+	// quadrantChart
+	//     title Reach and Engagement
+	//     Campaign A: [0.30, 0.60]
 }

--- a/mermaid/radar/examples_test.go
+++ b/mermaid/radar/examples_test.go
@@ -3,6 +3,7 @@
 package radar_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -43,4 +44,197 @@ func ExampleDiagram() {
 	//   max 100
 	//   min 0
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every radar chart has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = radar.NewDiagram(os.Stdout).
+		Axis("Math", "Science").Curve("Alice", 85, 90).
+		Build()
+
+	// Output:
+	// radar-beta
+	//   axis a1["Math"], a2["Science"]
+	//   curve c1["Alice"]{85, 90}
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := radar.NewDiagram(io.Discard).
+		Axis("Math", "Science").Curve("Alice", 85, 90).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// radar-beta
+	//   axis a1["Math"], a2["Science"]
+	//   curve c1["Alice"]{85, 90}
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := radar.NewDiagram(nil).
+		Axis("Math", "Science").Curve("Alice", 85, 90).
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := radar.NewDiagram(io.Discard).
+		Curve("Alice", 85, 90)
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: <nil>
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = radar.NewDiagram(os.Stdout).
+		Axis("Math", "Science").Curve("Alice", 85, 90).
+		LF().
+		Axis("Math", "Science").Curve("Alice", 85, 90).
+		Build()
+
+	// Output:
+	// radar-beta
+	//   axis a1["Math"], a2["Science"]
+	//   curve c1["Alice"]{85, 90}
+	//
+	//   axis a3["Math"], a4["Science"]
+	//   curve c2["Alice"]{85, 90}
+}
+
+// ExampleDiagram_full shows a radar chart built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := radar.NewDiagram(io.Discard).
+		Axis("Math", "Science").Curve("Alice", 85, 90).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// radar-beta
+	//   axis a1["Math"], a2["Science"]
+	//   curve c1["Alice"]{85, 90}
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []radar.Option{radar.WithTitle("Overview")}
+
+	_ = radar.NewDiagram(os.Stdout, options...).
+		Axis("Math", "Science").Curve("Alice", 85, 90).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// radar-beta
+	//   axis a1["Math"], a2["Science"]
+	//   curve c1["Alice"]{85, 90}
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = radar.NewDiagram(os.Stdout, radar.WithTitle("Overview")).
+		Axis("Math", "Science").Curve("Alice", 85, 90).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// radar-beta
+	//   axis a1["Math"], a2["Science"]
+	//   curve c1["Alice"]{85, 90}
+}
+
+// ExampleDiagram_Axis declares the axes, in order. Every curve then gives its
+// values in that same order. mermaid wants an identifier in front of each
+// label; nothing in a radar chart refers to one, so the package numbers them
+// and the caller passes only the labels.
+func ExampleDiagram_Axis() {
+	_ = radar.NewDiagram(os.Stdout).
+		Axis("Math", "Science", "English").
+		Curve("Alice", 85, 90, 80).
+		Build()
+
+	// Output:
+	// radar-beta
+	//   axis a1["Math"], a2["Science"], a3["English"]
+	//   curve c1["Alice"]{85, 90, 80}
+}
+
+// ExampleDiagram_Curve adds one subject's values, in the order the axes were
+// declared.
+func ExampleDiagram_Curve() {
+	_ = radar.NewDiagram(os.Stdout).
+		Axis("Math", "Science").
+		Curve("Alice", 85, 90).
+		Curve("Bob", 70, 75).
+		Build()
+
+	// Output:
+	// radar-beta
+	//   axis a1["Math"], a2["Science"]
+	//   curve c1["Alice"]{85, 90}
+	//   curve c2["Bob"]{70, 75}
+}
+
+// ExampleDiagram_Max sets the outer edge of the chart. Without it mermaid picks
+// a bound from the values, so two charts drawn from different data cannot be
+// compared by eye.
+func ExampleDiagram_Max() {
+	_ = radar.NewDiagram(os.Stdout).
+		Axis("Math", "Science").
+		Curve("Alice", 85, 90).
+		Max(100).
+		Build()
+
+	// Output:
+	// radar-beta
+	//   axis a1["Math"], a2["Science"]
+	//   curve c1["Alice"]{85, 90}
+	//   max 100
+}
+
+// ExampleDiagram_Min sets the center of the chart.
+func ExampleDiagram_Min() {
+	_ = radar.NewDiagram(os.Stdout).
+		Axis("Math", "Science").
+		Curve("Alice", 85, 90).
+		Min(0).
+		Max(100).
+		Build()
+
+	// Output:
+	// radar-beta
+	//   axis a1["Math"], a2["Science"]
+	//   curve c1["Alice"]{85, 90}
+	//   min 0
+	//   max 100
 }

--- a/mermaid/requirement/examples_test.go
+++ b/mermaid/requirement/examples_test.go
@@ -3,6 +3,7 @@
 package requirement_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -54,4 +55,1220 @@ func ExampleDiagram() {
 	//     }
 	//     AuthService - satisfies -> Login
 	// ```
+}
+
+// ExampleDiagram_Requirement adds a plain requirement.
+func ExampleDiagram_Requirement() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("The system shall log in", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement "The system shall log in" {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleDiagram_FunctionalRequirement adds a requirement about what the system does.
+func ExampleDiagram_FunctionalRequirement() {
+	_ = requirement.NewDiagram(os.Stdout).
+		FunctionalRequirement("The system shall log in", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     functionalRequirement "The system shall log in" {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleDiagram_InterfaceRequirement adds a requirement about how it is talked to.
+func ExampleDiagram_InterfaceRequirement() {
+	_ = requirement.NewDiagram(os.Stdout).
+		InterfaceRequirement("The system shall log in", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     interfaceRequirement "The system shall log in" {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleDiagram_PerformanceRequirement adds a requirement about how fast or how much.
+func ExampleDiagram_PerformanceRequirement() {
+	_ = requirement.NewDiagram(os.Stdout).
+		PerformanceRequirement("The system shall log in", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     performanceRequirement "The system shall log in" {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleDiagram_PhysicalRequirement adds a requirement about the hardware it runs on.
+func ExampleDiagram_PhysicalRequirement() {
+	_ = requirement.NewDiagram(os.Stdout).
+		PhysicalRequirement("The system shall log in", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     physicalRequirement "The system shall log in" {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleDiagram_DesignConstraint adds a limit on how the system may be built.
+func ExampleDiagram_DesignConstraint() {
+	_ = requirement.NewDiagram(os.Stdout).
+		DesignConstraint("The system shall log in", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     designConstraint "The system shall log in" {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleDiagram_Contains says that the first named thing holds the second.
+func ExampleDiagram_Contains() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		Contains("login", "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - contains -> "auth service"
+}
+
+// ExampleDiagram_Copies says that the first named thing copies the second.
+func ExampleDiagram_Copies() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		Copies("login", "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - copies -> "auth service"
+}
+
+// ExampleDiagram_Derives says that the first named thing is derived from the second.
+func ExampleDiagram_Derives() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		Derives("login", "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - derives -> "auth service"
+}
+
+// ExampleDiagram_Satisfies says that the first named thing satisfies the second.
+func ExampleDiagram_Satisfies() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		Satisfies("login", "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - satisfies -> "auth service"
+}
+
+// ExampleDiagram_Verifies says that the first named thing verifies the second.
+func ExampleDiagram_Verifies() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		Verifies("login", "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - verifies -> "auth service"
+}
+
+// ExampleDiagram_Refines says that the first named thing refines the second.
+func ExampleDiagram_Refines() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		Refines("login", "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - refines -> "auth service"
+}
+
+// ExampleDiagram_Traces says that the first named thing traces to the second.
+func ExampleDiagram_Traces() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		Traces("login", "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - traces -> "auth service"
+}
+
+// ExampleSourceRelationBuilder_Contains says that the source named by From holds
+// the thing given here.
+func ExampleSourceRelationBuilder_Contains() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		From("login").
+		Contains("auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - contains -> "auth service"
+}
+
+// ExampleSourceRelationBuilder_Copies says that the source named by From copies
+// the thing given here.
+func ExampleSourceRelationBuilder_Copies() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		From("login").
+		Copies("auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - copies -> "auth service"
+}
+
+// ExampleSourceRelationBuilder_Derives says that the source named by From is derived from
+// the thing given here.
+func ExampleSourceRelationBuilder_Derives() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		From("login").
+		Derives("auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - derives -> "auth service"
+}
+
+// ExampleSourceRelationBuilder_Satisfies says that the source named by From satisfies
+// the thing given here.
+func ExampleSourceRelationBuilder_Satisfies() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		From("login").
+		Satisfies("auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - satisfies -> "auth service"
+}
+
+// ExampleSourceRelationBuilder_Verifies says that the source named by From verifies
+// the thing given here.
+func ExampleSourceRelationBuilder_Verifies() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		From("login").
+		Verifies("auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - verifies -> "auth service"
+}
+
+// ExampleSourceRelationBuilder_Refines says that the source named by From refines
+// the thing given here.
+func ExampleSourceRelationBuilder_Refines() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		From("login").
+		Refines("auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - refines -> "auth service"
+}
+
+// ExampleSourceRelationBuilder_Traces says that the source named by From traces to
+// the thing given here.
+func ExampleSourceRelationBuilder_Traces() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest), requirement.WithText("The system shall log a user in.")).
+		Element("auth service").
+		From("login").
+		Traces("auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//     }
+	//     login - traces -> "auth service"
+}
+
+// ExampleNewDiagram shows the shape every requirement diagram has: a writer,
+// the requirements, what they relate to, and Build.
+//
+// A requirement needs all four of its fields. mermaid draws the block from
+// them, and leaving one out is recorded as an error rather than drawn short.
+func ExampleNewDiagram() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest)).
+		Element("auth service", requirement.WithElementType("service")).
+		Satisfies("login", "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     login - satisfies -> "auth service"
+}
+
+// ExampleDiagram_RequirementOfType adds a requirement whose kind is named
+// outright, for code that decides between the kinds rather than picking one.
+func ExampleDiagram_RequirementOfType() {
+	_ = requirement.NewDiagram(os.Stdout).
+		RequirementOfType(requirement.RequirementTypePerformance, "latency", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest)).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     performanceRequirement latency {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleDiagram_Element adds something that is not a requirement: the part of
+// the system a requirement is about.
+func ExampleDiagram_Element() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service", requirement.WithElementType("service")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+}
+
+// ExampleDiagram_Relation joins two things with a relationship named outright.
+func ExampleDiagram_Relation() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service", requirement.WithElementType("service")).
+		Relation("login", requirement.RelationshipSatisfies, "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     login - satisfies -> "auth service"
+}
+
+// ExampleDiagram_From names a source once and hangs several relationships off
+// it, which keeps a requirement with many links readable.
+func ExampleDiagram_From() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service", requirement.WithElementType("service")).
+		Element("session store", requirement.WithElementType("service")).
+		From("login").
+		Satisfies("auth service").
+		Traces("session store").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     element "session store" {
+	//         type: "service"
+	//     }
+	//     login - satisfies -> "auth service"
+	//     login - traces -> "session store"
+}
+
+// ExampleSourceRelationBuilder shows what From returns: the same source, with
+// one relationship per call.
+func ExampleSourceRelationBuilder() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service", requirement.WithElementType("service")).
+		From("login").
+		Satisfies("auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     login - satisfies -> "auth service"
+}
+
+// ExampleSourceRelationBuilder_Relation joins the source to something with a
+// relationship named outright.
+func ExampleSourceRelationBuilder_Relation() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service", requirement.WithElementType("service")).
+		From("login").
+		Relation(requirement.RelationshipSatisfies, "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     login - satisfies -> "auth service"
+}
+
+// ExampleDiagram_SetDirection says which way the diagram is laid out.
+func ExampleDiagram_SetDirection() {
+	_ = requirement.NewDiagram(os.Stdout).
+		SetDirection(requirement.DirectionLR).
+		Element("auth service", requirement.WithElementType("service")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     direction LR
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+}
+
+// ExampleDiagram_Style colors one thing outright.
+func ExampleDiagram_Style() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service", requirement.WithElementType("service")).
+		Style("auth service", "fill:#f9f").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     style auth service fill:#f9f
+}
+
+// ExampleDiagram_ClassDef names a style so several things can share it.
+func ExampleDiagram_ClassDef() {
+	_ = requirement.NewDiagram(os.Stdout).
+		ClassDef("urgent", "fill:#f96").
+		Element("auth service", requirement.WithElementType("service")).
+		Class("auth service", "urgent").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     classDef urgent fill:#f96
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     class auth service urgent
+}
+
+// ExampleDiagram_ClassDefs names several styles at once.
+func ExampleDiagram_ClassDefs() {
+	_ = requirement.NewDiagram(os.Stdout).
+		ClassDefs(
+			requirement.Def("urgent", "fill:#f96"),
+			requirement.Def("done", "fill:#9f6"),
+		).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     classDef urgent fill:#f96
+	//     classDef done fill:#9f6
+}
+
+// ExampleDef describes one named style, for passing to ClassDefs.
+func ExampleDef() {
+	_ = requirement.NewDiagram(os.Stdout).
+		ClassDefs(requirement.Def("urgent", "fill:#f96")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     classDef urgent fill:#f96
+}
+
+// ExampleDiagram_Class applies named styles to things.
+func ExampleDiagram_Class() {
+	_ = requirement.NewDiagram(os.Stdout).
+		ClassDef("urgent", "fill:#f96").
+		Element("auth service", requirement.WithElementType("service")).
+		Class("auth service", "urgent").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     classDef urgent fill:#f96
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     class auth service urgent
+}
+
+// ExampleDiagram_ClassShorthand applies styles with mermaid's ":::" form, which
+// says the same thing as Class in one token.
+func ExampleDiagram_ClassShorthand() {
+	_ = requirement.NewDiagram(os.Stdout).
+		ClassDef("urgent", "fill:#f96").
+		Element("auth service", requirement.WithElementType("service")).
+		ClassShorthand("auth service", "urgent").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     classDef urgent fill:#f96
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     "auth service":::urgent
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := requirement.NewDiagram(io.Discard).
+		Element("auth service", requirement.WithElementType("service")).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the error the chain
+// recorded.
+func ExampleDiagram_Build() {
+	err := requirement.NewDiagram(nil).
+		Element("auth service", requirement.WithElementType("service")).
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does. A requirement missing
+// one of its four fields is exactly the kind of thing it reports.
+func ExampleDiagram_Error() {
+	d := requirement.NewDiagram(io.Discard).Requirement("login", requirement.WithID("1"))
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: requirement text must not be empty
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service", requirement.WithElementType("service")).
+		LF().
+		Element("session store", requirement.WithElementType("service")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//
+	//     element "session store" {
+	//         type: "service"
+	//     }
+}
+
+// ExampleWithID gives a requirement its number, which is how a specification
+// refers to it outside the diagram.
+func ExampleWithID() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest)).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleWithText spells the requirement out, where the name is only a handle.
+func ExampleWithText() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest)).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleWithRisk says how much is at stake if the requirement is not met.
+func ExampleWithRisk() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest)).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleRisk shows the three levels a requirement can carry.
+func ExampleRisk() {
+	for _, risk := range []requirement.Risk{
+		requirement.RiskLow, requirement.RiskMedium, requirement.RiskHigh,
+	} {
+		_ = requirement.NewDiagram(os.Stdout).
+			Requirement("login",
+				requirement.WithID("1"),
+				requirement.WithText("The system shall log a user in."),
+				requirement.WithRisk(risk),
+				requirement.WithVerifyMethod(requirement.VerifyMethodTest),
+			).
+			Build()
+		fmt.Println()
+	}
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Low
+	//         verifymethod: Test
+	//     }
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: High
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleWithVerifyMethod says how the requirement will be shown to be met.
+func ExampleWithVerifyMethod() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Requirement("login", requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskMedium),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest)).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleVerifyMethod shows the four ways a requirement can be shown to be met.
+func ExampleVerifyMethod() {
+	for _, method := range []requirement.VerifyMethod{
+		requirement.VerifyMethodAnalysis,
+		requirement.VerifyMethodInspection,
+		requirement.VerifyMethodTest,
+		requirement.VerifyMethodDemonstration,
+	} {
+		_ = requirement.NewDiagram(os.Stdout).
+			Requirement("login",
+				requirement.WithID("1"),
+				requirement.WithText("The system shall log a user in."),
+				requirement.WithRisk(requirement.RiskMedium),
+				requirement.WithVerifyMethod(method),
+			).
+			Build()
+		fmt.Println()
+	}
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Analysis
+	//     }
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Inspection
+	//     }
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Demonstration
+	//     }
+}
+
+// ExampleWithRequirementClasses styles a requirement as it is declared, which
+// saves a separate Class call.
+func ExampleWithRequirementClasses() {
+	_ = requirement.NewDiagram(os.Stdout).
+		ClassDef("urgent", "fill:#f96").
+		Requirement("login",
+			requirement.WithID("1"),
+			requirement.WithText("The system shall log a user in."),
+			requirement.WithRisk(requirement.RiskHigh),
+			requirement.WithVerifyMethod(requirement.VerifyMethodTest),
+			requirement.WithRequirementClasses("urgent"),
+		).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     classDef urgent fill:#f96
+	//     requirement login:::urgent {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: High
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleWithElementType says what kind of thing an element is.
+func ExampleWithElementType() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service", requirement.WithElementType("service")).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+}
+
+// ExampleWithDocRef points an element at where it is written down.
+func ExampleWithDocRef() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service",
+			requirement.WithElementType("service"),
+			requirement.WithDocRef("docs/auth.md"),
+		).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//         docRef: "docs/auth.md"
+	//     }
+}
+
+// ExampleWithElementClasses styles an element as it is declared.
+func ExampleWithElementClasses() {
+	_ = requirement.NewDiagram(os.Stdout).
+		ClassDef("external", "fill:#eee").
+		Element("auth service",
+			requirement.WithElementType("service"),
+			requirement.WithElementClasses("external"),
+		).
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     classDef external fill:#eee
+	//     element "auth service":::external {
+	//         type: "service"
+	//     }
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = requirement.NewDiagram(os.Stdout, requirement.WithTitle("Login")).
+		Element("auth service", requirement.WithElementType("service")).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Login"
+	// ---
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+}
+
+// ExampleRequirementType shows the six kinds a requirement can be, for the form
+// that names one outright.
+func ExampleRequirementType() {
+	for _, kind := range []requirement.RequirementType{
+		requirement.RequirementTypeRequirement,
+		requirement.RequirementTypeFunctional,
+		requirement.RequirementTypeInterface,
+		requirement.RequirementTypePerformance,
+		requirement.RequirementTypePhysical,
+		requirement.RequirementTypeDesignConstraint,
+	} {
+		_ = requirement.NewDiagram(os.Stdout).
+			RequirementOfType(kind, "login",
+				requirement.WithID("1"),
+				requirement.WithText("The system shall log a user in."),
+				requirement.WithRisk(requirement.RiskMedium),
+				requirement.WithVerifyMethod(requirement.VerifyMethodTest),
+			).
+			Build()
+		fmt.Println()
+	}
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	// requirementDiagram
+	//     functionalRequirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	// requirementDiagram
+	//     interfaceRequirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	// requirementDiagram
+	//     performanceRequirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	// requirementDiagram
+	//     physicalRequirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+	// requirementDiagram
+	//     designConstraint login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: Medium
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleRelationship shows the seven ways two things can be related.
+func ExampleRelationship() {
+	_ = requirement.NewDiagram(os.Stdout).
+		Element("auth service", requirement.WithElementType("service")).
+		Relation("login", requirement.RelationshipSatisfies, "auth service").
+		Relation("login", requirement.RelationshipTraces, "auth service").
+		Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	//     login - satisfies -> "auth service"
+	//     login - traces -> "auth service"
+}
+
+// ExampleDirection shows the four ways a diagram can be laid out.
+func ExampleDirection() {
+	for _, direction := range []requirement.Direction{
+		requirement.DirectionTB,
+		requirement.DirectionBT,
+		requirement.DirectionLR,
+		requirement.DirectionRL,
+	} {
+		_ = requirement.NewDiagram(os.Stdout).
+			SetDirection(direction).
+			Element("auth service", requirement.WithElementType("service")).
+			Build()
+		fmt.Println()
+	}
+
+	// Output:
+	// requirementDiagram
+	//     direction TB
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	// requirementDiagram
+	//     direction BT
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	// requirementDiagram
+	//     direction LR
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+	// requirementDiagram
+	//     direction RL
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+}
+
+// ExampleClassDefSpec is one named style, as Def returns it.
+func ExampleClassDefSpec() {
+	specs := []requirement.ClassDefSpec{
+		requirement.Def("urgent", "fill:#f96"),
+		requirement.Def("done", "fill:#9f6"),
+	}
+
+	_ = requirement.NewDiagram(os.Stdout).ClassDefs(specs...).Build()
+
+	// Output:
+	// requirementDiagram
+	//     classDef urgent fill:#f96
+	//     classDef done fill:#9f6
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []requirement.Option{requirement.WithTitle("Login")}
+
+	_ = requirement.NewDiagram(os.Stdout, options...).
+		Element("auth service", requirement.WithElementType("service")).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Login"
+	// ---
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
+}
+
+// ExampleRequirementOption shows what a RequirementOption is: a function that
+// changes how a requirement is written, passed after its name.
+func ExampleRequirementOption() {
+	options := []requirement.RequirementOption{
+		requirement.WithID("1"),
+		requirement.WithText("The system shall log a user in."),
+		requirement.WithRisk(requirement.RiskHigh),
+		requirement.WithVerifyMethod(requirement.VerifyMethodTest),
+	}
+
+	_ = requirement.NewDiagram(os.Stdout).Requirement("login", options...).Build()
+
+	// Output:
+	// requirementDiagram
+	//     requirement login {
+	//         id: "1"
+	//         text: "The system shall log a user in."
+	//         risk: High
+	//         verifymethod: Test
+	//     }
+}
+
+// ExampleElementOption shows what an ElementOption is: a function that changes
+// how an element is written, passed after its name.
+func ExampleElementOption() {
+	options := []requirement.ElementOption{requirement.WithElementType("service")}
+
+	_ = requirement.NewDiagram(os.Stdout).Element("auth service", options...).Build()
+
+	// Output:
+	// requirementDiagram
+	//     element "auth service" {
+	//         type: "service"
+	//     }
 }

--- a/mermaid/sankey/examples_test.go
+++ b/mermaid/sankey/examples_test.go
@@ -3,6 +3,7 @@
 package sankey_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -37,4 +38,148 @@ func ExampleDiagram() {
 	// Electricity,Homes,120
 	// Electricity,"Losses, and more",30
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every sankey diagram has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = sankey.NewDiagram(os.Stdout).
+		Link("Bill", "Electricity", 120).
+		Build()
+
+	// Output:
+	// sankey-beta
+	//
+	// Bill,Electricity,120
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := sankey.NewDiagram(io.Discard).
+		Link("Bill", "Electricity", 120).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// sankey-beta
+	//
+	// Bill,Electricity,120
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := sankey.NewDiagram(nil).
+		Link("Bill", "Electricity", 120).
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := sankey.NewDiagram(io.Discard).
+		Link("", "Electricity", 120)
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: source must not be empty
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = sankey.NewDiagram(os.Stdout).
+		Link("Bill", "Electricity", 120).
+		LF().
+		Link("Bill", "Electricity", 120).
+		Build()
+
+	// Output:
+	// sankey-beta
+	//
+	// Bill,Electricity,120
+	//
+	// Bill,Electricity,120
+}
+
+// ExampleDiagram_full shows a sankey diagram built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := sankey.NewDiagram(io.Discard).
+		Link("Bill", "Electricity", 120).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// sankey-beta
+	//
+	// Bill,Electricity,120
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []sankey.Option{sankey.WithTitle("Overview")}
+
+	_ = sankey.NewDiagram(os.Stdout, options...).
+		Link("Bill", "Electricity", 120).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// sankey-beta
+	//
+	// Bill,Electricity,120
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = sankey.NewDiagram(os.Stdout, sankey.WithTitle("Overview")).
+		Link("Bill", "Electricity", 120).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// sankey-beta
+	//
+	// Bill,Electricity,120
+}
+
+// ExampleDiagram_Link adds one flow. The value is the width of the band drawn
+// between the two nodes, and a node appears in the diagram because a link names
+// it: there is nothing else to declare.
+func ExampleDiagram_Link() {
+	_ = sankey.NewDiagram(os.Stdout).
+		Link("Bill", "Electricity", 120).
+		Link("Bill", "Gas", 80).
+		Link("Electricity", "Lighting", 45).
+		Build()
+
+	// Output:
+	// sankey-beta
+	//
+	// Bill,Electricity,120
+	// Bill,Gas,80
+	// Electricity,Lighting,45
 }

--- a/mermaid/sequence/examples_test.go
+++ b/mermaid/sequence/examples_test.go
@@ -3,6 +3,8 @@
 package sequence_test
 
 import (
+	"fmt"
+	"io"
 	"os"
 
 	md "github.com/nao1215/markdown"
@@ -61,4 +63,918 @@ func ExampleDiagram() {
 	//
 	//     David-->>Sophia: wake up, wake up
 	// ```
+}
+
+// ExampleDiagram_SyncRequest draws a solid arrow with a filled head, the ordinary call.
+func ExampleDiagram_SyncRequest() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleDiagram_SyncRequestf draws the same from a format string.
+func ExampleDiagram_SyncRequestf() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncRequestf("Alice", "Bob", "Retry %d of %d", 2, 3).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: Retry 2 of 3
+}
+
+// ExampleDiagram_SyncResponse draws a dashed arrow with a filled head, the ordinary reply.
+func ExampleDiagram_SyncResponse() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncResponse("Bob", "Alice", "Fine, thanks").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob-->>Alice: Fine, thanks
+}
+
+// ExampleDiagram_SyncResponsef draws the same from a format string.
+func ExampleDiagram_SyncResponsef() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncResponsef("Bob", "Alice", "%d items", 7).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob-->>Alice: 7 items
+}
+
+// ExampleDiagram_AsyncRequest draws a call that does not wait for a reply.
+func ExampleDiagram_AsyncRequest() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AsyncRequest("Alice", "Bob", "Start the job").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->)Bob: Start the job
+}
+
+// ExampleDiagram_AsyncRequestf draws the same from a format string.
+func ExampleDiagram_AsyncRequestf() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AsyncRequestf("Alice", "Bob", "Start job %d", 7).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->)Bob: Start job 7
+}
+
+// ExampleDiagram_AsyncResponse draws a reply to a call that was not waiting.
+func ExampleDiagram_AsyncResponse() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AsyncResponse("Bob", "Alice", "Job finished").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob--)Alice: Job finished
+}
+
+// ExampleDiagram_AsyncResponsef draws the same from a format string.
+func ExampleDiagram_AsyncResponsef() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AsyncResponsef("Bob", "Alice", "Job %d finished", 7).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob--)Alice: Job 7 finished
+}
+
+// ExampleDiagram_RequestError draws a call that failed, drawn with a cross at the end.
+func ExampleDiagram_RequestError() {
+	_ = sequence.NewDiagram(os.Stdout).
+		RequestError("Alice", "Bob", "Timed out").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice-xBob: Timed out
+}
+
+// ExampleDiagram_RequestErrorf draws the same from a format string.
+func ExampleDiagram_RequestErrorf() {
+	_ = sequence.NewDiagram(os.Stdout).
+		RequestErrorf("Alice", "Bob", "Timed out after %ds", 30).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice-xBob: Timed out after 30s
+}
+
+// ExampleDiagram_ResponseError draws a reply that failed.
+func ExampleDiagram_ResponseError() {
+	_ = sequence.NewDiagram(os.Stdout).
+		ResponseError("Bob", "Alice", "Refused").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob--xAlice: Refused
+}
+
+// ExampleDiagram_ResponseErrorf draws the same from a format string.
+func ExampleDiagram_ResponseErrorf() {
+	_ = sequence.NewDiagram(os.Stdout).
+		ResponseErrorf("Bob", "Alice", "Refused with %d", 503).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob--xAlice: Refused with 503
+}
+
+// ExampleDiagram_SyncRequestWithActivation draws a call that also turns the receiver's activation bar on.
+func ExampleDiagram_SyncRequestWithActivation() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncRequestWithActivation("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>+Bob: How are you?
+}
+
+// ExampleDiagram_SyncRequestfWithActivation draws the same from a format string.
+func ExampleDiagram_SyncRequestfWithActivation() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncRequestfWithActivation("Alice", "Bob", "Retry %d", 2).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>+Bob: Retry 2
+}
+
+// ExampleDiagram_SyncResponseWithActivation draws a reply that also turns the bar off.
+func ExampleDiagram_SyncResponseWithActivation() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncResponseWithActivation("Bob", "Alice", "Fine, thanks").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob-->>-Alice: Fine, thanks
+}
+
+// ExampleDiagram_SyncResponsefWithActivation draws the same from a format string.
+func ExampleDiagram_SyncResponsefWithActivation() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncResponsefWithActivation("Bob", "Alice", "%d items", 7).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob-->>-Alice: 7 items
+}
+
+// ExampleDiagram_AsyncRequestWithActivation draws an asynchronous call that turns the bar on.
+func ExampleDiagram_AsyncRequestWithActivation() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AsyncRequestWithActivation("Alice", "Bob", "Start the job").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>+Bob: Start the job
+}
+
+// ExampleDiagram_AsyncRequestfWithActivation draws the same from a format string.
+func ExampleDiagram_AsyncRequestfWithActivation() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AsyncRequestfWithActivation("Alice", "Bob", "Start job %d", 7).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>+Bob: Start job 7
+}
+
+// ExampleDiagram_AsyncResponseWithActivation draws an asynchronous reply that turns the bar off.
+func ExampleDiagram_AsyncResponseWithActivation() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AsyncResponseWithActivation("Bob", "Alice", "Job finished").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob-->>-Alice: Job finished
+}
+
+// ExampleDiagram_AsyncResponsefWithActivation draws the same from a format string.
+func ExampleDiagram_AsyncResponsefWithActivation() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AsyncResponsefWithActivation("Bob", "Alice", "Job %d finished", 7).
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Bob-->>-Alice: Job 7 finished
+}
+
+// ExampleNewDiagram shows the shape every sequence diagram has: a writer, the
+// participants, the messages between them, and Build.
+func ExampleNewDiagram() {
+	_ = sequence.NewDiagram(os.Stdout).
+		Participant("Alice").
+		Participant("Bob").
+		SyncRequest("Alice", "Bob", "How are you?").
+		SyncResponse("Bob", "Alice", "Fine, thanks").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     participant Alice
+	//     participant Bob
+	//     Alice->>Bob: How are you?
+	//     Bob-->>Alice: Fine, thanks
+}
+
+// ExampleDiagram_Participant declares someone taking part, drawn as a box.
+// Declaring one is what fixes the order they appear in; a participant a message
+// names is drawn anyway, at the point it is first mentioned.
+func ExampleDiagram_Participant() {
+	_ = sequence.NewDiagram(os.Stdout).
+		Participant("Bob").
+		Participant("Alice").
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     participant Bob
+	//     participant Alice
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleDiagram_Actor declares someone taking part, drawn as a stick figure
+// rather than a box.
+func ExampleDiagram_Actor() {
+	_ = sequence.NewDiagram(os.Stdout).
+		Actor("Alice").
+		Participant("Bob").
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     actor Alice
+	//     participant Bob
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleDiagram_CreateParticipant brings a participant into being partway
+// through, which is how a diagram shows something being started rather than
+// having been there all along.
+func ExampleDiagram_CreateParticipant() {
+	_ = sequence.NewDiagram(os.Stdout).
+		Participant("Alice").
+		CreateParticipant("Worker").
+		SyncRequest("Alice", "Worker", "Start").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     participant Alice
+	//     create participant Worker
+	//     Alice->>Worker: Start
+}
+
+// ExampleDiagram_DestroyParticipant ends a participant, drawn with a cross.
+func ExampleDiagram_DestroyParticipant() {
+	_ = sequence.NewDiagram(os.Stdout).
+		Participant("Alice").
+		Participant("Worker").
+		SyncRequest("Alice", "Worker", "Stop").
+		DestroyParticipant("Worker").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     participant Alice
+	//     participant Worker
+	//     Alice->>Worker: Stop
+	//     destroy Worker
+}
+
+// ExampleDiagram_CreateActor brings an actor into being partway through.
+func ExampleDiagram_CreateActor() {
+	_ = sequence.NewDiagram(os.Stdout).
+		Participant("System").
+		CreateActor("Reviewer").
+		SyncRequest("System", "Reviewer", "Please review").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     participant System
+	//     create actor Reviewer
+	//     System->>Reviewer: Please review
+}
+
+// ExampleDiagram_DestroyActor ends an actor.
+func ExampleDiagram_DestroyActor() {
+	_ = sequence.NewDiagram(os.Stdout).
+		Actor("Reviewer").
+		DestroyActor("Reviewer").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     actor Reviewer
+	//     destroy Reviewer
+}
+
+// ExampleDiagram_Activate turns a participant's activation bar on, which shows
+// it doing something rather than waiting.
+func ExampleDiagram_Activate() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Activate("Bob").
+		SyncResponse("Bob", "Alice", "Fine, thanks").
+		Deactivate("Bob").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+	//     activate Bob
+	//     Bob-->>Alice: Fine, thanks
+	//     deactivate Bob
+}
+
+// ExampleDiagram_Deactivate turns the bar off again.
+func ExampleDiagram_Deactivate() {
+	_ = sequence.NewDiagram(os.Stdout).
+		Activate("Bob").
+		Deactivate("Bob").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     activate Bob
+	//     deactivate Bob
+}
+
+// ExampleDiagram_NoteOver puts a note across one or more participants. Two
+// named with a comma between them is a note spanning both.
+func ExampleDiagram_NoteOver() {
+	_ = sequence.NewDiagram(os.Stdout).
+		NoteOver("Alice", "Thinking it over").
+		NoteOver("Alice,Bob", "Both are waiting").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     note over Alice: Thinking it over
+	//     note over Alice,Bob: Both are waiting
+}
+
+// ExampleDiagram_NoteRightOf puts a note to the right of a participant.
+func ExampleDiagram_NoteRightOf() {
+	_ = sequence.NewDiagram(os.Stdout).
+		NoteRightOf("Bob", "Bob is busy").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     note right of Bob: Bob is busy
+}
+
+// ExampleDiagram_NoteLeftOf puts a note to the left of a participant.
+func ExampleDiagram_NoteLeftOf() {
+	_ = sequence.NewDiagram(os.Stdout).
+		NoteLeftOf("Alice", "Alice is waiting").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     note left of Alice: Alice is waiting
+}
+
+// ExampleDiagram_LoopStart opens a block that repeats, and LoopEnd closes it.
+func ExampleDiagram_LoopStart() {
+	_ = sequence.NewDiagram(os.Stdout).
+		LoopStart("every minute").
+		SyncRequest("Alice", "Bob", "Still there?").
+		LoopEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     loop every minute
+	//     Alice->>Bob: Still there?
+	//     end
+}
+
+// ExampleDiagram_LoopEnd closes the block LoopStart opened.
+func ExampleDiagram_LoopEnd() {
+	_ = sequence.NewDiagram(os.Stdout).
+		LoopStart("every minute").
+		SyncRequest("Alice", "Bob", "Still there?").
+		LoopEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     loop every minute
+	//     Alice->>Bob: Still there?
+	//     end
+}
+
+// ExampleDiagram_AltStart opens a choice between paths. AltElse begins each
+// alternative and AltEnd closes the whole thing.
+func ExampleDiagram_AltStart() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AltStart("is logged in").
+		SyncResponse("Bob", "Alice", "Here you are").
+		AltElse("is not").
+		SyncResponse("Bob", "Alice", "Please log in").
+		AltEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     alt is logged in
+	//     Bob-->>Alice: Here you are
+	//     else is not
+	//     Bob-->>Alice: Please log in
+	//     end
+}
+
+// ExampleDiagram_AltElse begins an alternative path.
+func ExampleDiagram_AltElse() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AltStart("is logged in").
+		AltElse("is not").
+		AltEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     alt is logged in
+	//     else is not
+	//     end
+}
+
+// ExampleDiagram_AltEnd closes the choice AltStart opened.
+func ExampleDiagram_AltEnd() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AltStart("is logged in").
+		AltEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     alt is logged in
+	//     end
+}
+
+// ExampleDiagram_OptStart opens a block that may or may not happen, which is a
+// choice with only one path.
+func ExampleDiagram_OptStart() {
+	_ = sequence.NewDiagram(os.Stdout).
+		OptStart("if the cache is cold").
+		SyncRequest("Bob", "Database", "Fetch").
+		OptEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     opt if the cache is cold
+	//     Bob->>Database: Fetch
+	//     end
+}
+
+// ExampleDiagram_OptEnd closes the block OptStart opened.
+func ExampleDiagram_OptEnd() {
+	_ = sequence.NewDiagram(os.Stdout).
+		OptStart("if the cache is cold").
+		OptEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     opt if the cache is cold
+	//     end
+}
+
+// ExampleDiagram_ParallelStart opens paths that run at the same time.
+// ParallelAnd begins each one after the first and ParallelEnd closes them.
+func ExampleDiagram_ParallelStart() {
+	_ = sequence.NewDiagram(os.Stdout).
+		ParallelStart("lint").
+		SyncRequest("CI", "Linter", "Run").
+		ParallelAnd("test").
+		SyncRequest("CI", "Tester", "Run").
+		ParallelEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     par lint
+	//     CI->>Linter: Run
+	//     and test
+	//     CI->>Tester: Run
+	//     end
+}
+
+// ExampleDiagram_ParallelAnd begins another path running at the same time.
+func ExampleDiagram_ParallelAnd() {
+	_ = sequence.NewDiagram(os.Stdout).
+		ParallelStart("lint").
+		ParallelAnd("test").
+		ParallelEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     par lint
+	//     and test
+	//     end
+}
+
+// ExampleDiagram_ParallelEnd closes the paths ParallelStart opened.
+func ExampleDiagram_ParallelEnd() {
+	_ = sequence.NewDiagram(os.Stdout).
+		ParallelStart("lint").
+		ParallelEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     par lint
+	//     end
+}
+
+// ExampleDiagram_CriticalStart opens a block that has to happen, with
+// CriticalOption for each thing that can go wrong instead.
+func ExampleDiagram_CriticalStart() {
+	_ = sequence.NewDiagram(os.Stdout).
+		CriticalStart("connect to the database").
+		SyncRequest("Service", "Database", "Connect").
+		CriticalOption("the network is down").
+		SyncRequest("Service", "Operator", "Page").
+		CriticalEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     critical connect to the database
+	//     Service->>Database: Connect
+	//     option the network is down
+	//     Service->>Operator: Page
+	//     end
+}
+
+// ExampleDiagram_CriticalOption begins what happens instead when the critical
+// block cannot go ahead.
+func ExampleDiagram_CriticalOption() {
+	_ = sequence.NewDiagram(os.Stdout).
+		CriticalStart("connect to the database").
+		CriticalOption("the network is down").
+		CriticalEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     critical connect to the database
+	//     option the network is down
+	//     end
+}
+
+// ExampleDiagram_CriticalEnd closes the block CriticalStart opened.
+func ExampleDiagram_CriticalEnd() {
+	_ = sequence.NewDiagram(os.Stdout).
+		CriticalStart("connect to the database").
+		CriticalEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     critical connect to the database
+	//     end
+}
+
+// ExampleDiagram_BreakStart opens a block that stops the flow when it happens.
+func ExampleDiagram_BreakStart() {
+	_ = sequence.NewDiagram(os.Stdout).
+		BreakStart("the request is invalid").
+		SyncResponse("Bob", "Alice", "400 Bad Request").
+		BreakEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     break the request is invalid
+	//     Bob-->>Alice: 400 Bad Request
+	//     end
+}
+
+// ExampleDiagram_BreakEnd closes the block BreakStart opened.
+func ExampleDiagram_BreakEnd() {
+	_ = sequence.NewDiagram(os.Stdout).
+		BreakStart("the request is invalid").
+		BreakEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     break the request is invalid
+	//     end
+}
+
+// ExampleDiagram_BoxStart draws a box around several participants, which is how
+// a diagram says which of them belong to one system.
+func ExampleDiagram_BoxStart() {
+	_ = sequence.NewDiagram(os.Stdout).
+		BoxStart([]string{"Alice", "Bob"}).
+		Participant("Alice").
+		Participant("Bob").
+		BoxEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     box Alice & Bob
+	//     participant Alice
+	//     participant Bob
+	//     end
+}
+
+// ExampleDiagram_BoxEnd closes the box BoxStart opened.
+func ExampleDiagram_BoxEnd() {
+	_ = sequence.NewDiagram(os.Stdout).
+		BoxStart([]string{"Alice"}).
+		Participant("Alice").
+		BoxEnd().
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     box Alice
+	//     participant Alice
+	//     end
+}
+
+// ExampleDiagram_AutoNumber numbers the messages, so a discussion can refer to
+// one of them by number.
+func ExampleDiagram_AutoNumber() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AutoNumber().
+		SyncRequest("Alice", "Bob", "How are you?").
+		SyncResponse("Bob", "Alice", "Fine, thanks").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     autonumber
+	//     Alice->>Bob: How are you?
+	//     Bob-->>Alice: Fine, thanks
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := sequence.NewDiagram(io.Discard).
+		SyncRequest("Alice", "Bob", "How are you?").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the error the chain
+// recorded.
+func ExampleDiagram_Build() {
+	err := sequence.NewDiagram(nil).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := sequence.NewDiagram(io.Discard).SyncRequest("Alice", "Bob", "How are you?")
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: <nil>
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = sequence.NewDiagram(os.Stdout).
+		SyncRequest("Alice", "Bob", "How are you?").
+		LF().
+		SyncResponse("Bob", "Alice", "Fine, thanks").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+	//
+	//     Bob-->>Alice: Fine, thanks
+}
+
+// ExampleWithMirrorActors draws the actors along the bottom as well as the top,
+// which a long diagram wants so a reader does not have to scroll back.
+func ExampleWithMirrorActors() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithMirrorActors(true)).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleDiagram_AutoNumber_second shows that numbering is a call rather than
+// an option, so it can be turned on partway through a chain.
+func ExampleDiagram_AutoNumber_second() {
+	_ = sequence.NewDiagram(os.Stdout).
+		AutoNumber().
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     autonumber
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleNotePosition shows where a note can be placed. The constants are used
+// by the note methods rather than passed to them, and WithNoteAlign takes the
+// same wording as a string.
+func ExampleNotePosition() {
+	fmt.Println(sequence.NotePositionOver)
+	fmt.Println(sequence.NotePositionLeft)
+	fmt.Println(sequence.NotePositionRight)
+
+	// Output:
+	// over
+	// left of
+	// right of
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []sequence.Option{
+		sequence.WithMirrorActors(true),
+		sequence.WithActorFontSize(18),
+	}
+
+	_ = sequence.NewDiagram(os.Stdout, options...).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithActorFontSize sets the size of the actor names.
+func ExampleWithActorFontSize() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithActorFontSize(18)).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithActorFontFamily sets the typeface of the actor names.
+func ExampleWithActorFontFamily() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithActorFontFamily("Helvetica")).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithActorFontWeight sets the weight of the actor names.
+func ExampleWithActorFontWeight() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithActorFontWeight("bold")).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithMessageFontSize sets the size of the message text.
+func ExampleWithMessageFontSize() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithMessageFontSize(14)).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithMessageFontFamily sets the typeface of the message text.
+func ExampleWithMessageFontFamily() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithMessageFontFamily("Helvetica")).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithMessageFontWeight sets the weight of the message text.
+func ExampleWithMessageFontWeight() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithMessageFontWeight("bold")).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithNoteFontSize sets the size of the note text.
+func ExampleWithNoteFontSize() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithNoteFontSize(12)).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithNoteFontFamily sets the typeface of the note text.
+func ExampleWithNoteFontFamily() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithNoteFontFamily("Helvetica")).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithNoteFontWeight sets the weight of the note text.
+func ExampleWithNoteFontWeight() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithNoteFontWeight("bold")).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithNoteAlign sets which way the note text is aligned.
+func ExampleWithNoteAlign() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithNoteAlign("center")).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
+}
+
+// ExampleWithBottomMariginAdjustment adds space below the diagram.
+func ExampleWithBottomMariginAdjustment() {
+	_ = sequence.NewDiagram(os.Stdout, sequence.WithBottomMariginAdjustment(10)).
+		SyncRequest("Alice", "Bob", "How are you?").
+		Build()
+
+	// Output:
+	// sequenceDiagram
+	//     Alice->>Bob: How are you?
 }

--- a/mermaid/state/examples_test.go
+++ b/mermaid/state/examples_test.go
@@ -3,6 +3,8 @@
 package state_test
 
 import (
+	"fmt"
+	"io"
 	"os"
 
 	md "github.com/nao1215/markdown"
@@ -41,4 +43,533 @@ func ExampleDiagram() {
 	//     Moving --> Crash : sudden stop
 	//     Crash --> [*]
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every state diagram has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = state.NewDiagram(os.Stdout).
+		State("Draft", "Being written").Transition("Draft", "Review").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     Draft --> Review
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := state.NewDiagram(io.Discard).
+		State("Draft", "Being written").Transition("Draft", "Review").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     Draft --> Review
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := state.NewDiagram(nil).
+		State("Draft", "Being written").Transition("Draft", "Review").
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := state.NewDiagram(io.Discard).
+		State("", "")
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: <nil>
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = state.NewDiagram(os.Stdout).
+		State("Draft", "Being written").Transition("Draft", "Review").
+		LF().
+		State("Draft", "Being written").Transition("Draft", "Review").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     Draft --> Review
+	//
+	//     Draft : Being written
+	//     Draft --> Review
+}
+
+// ExampleDiagram_full shows a state diagram built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := state.NewDiagram(io.Discard).
+		State("Draft", "Being written").Transition("Draft", "Review").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     Draft --> Review
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []state.Option{state.WithTitle("Overview")}
+
+	_ = state.NewDiagram(os.Stdout, options...).
+		State("Draft", "Being written").Transition("Draft", "Review").
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     Draft --> Review
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = state.NewDiagram(os.Stdout, state.WithTitle("Overview")).
+		State("Draft", "Being written").Transition("Draft", "Review").
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     Draft --> Review
+}
+
+// ExampleDiagram_State declares a state and the description drawn inside it.
+func ExampleDiagram_State() {
+	_ = state.NewDiagram(os.Stdout).
+		State("Draft", "Being written").
+		State("Review", "Waiting on a reviewer").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     Review : Waiting on a reviewer
+}
+
+// ExampleDiagram_Transition draws an arrow between two states.
+func ExampleDiagram_Transition() {
+	_ = state.NewDiagram(os.Stdout).
+		Transition("Draft", "Review").
+		Transition("Review", "Published").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft --> Review
+	//     Review --> Published
+}
+
+// ExampleDiagram_TransitionWithNote labels the arrow with what causes it.
+func ExampleDiagram_TransitionWithNote() {
+	_ = state.NewDiagram(os.Stdout).
+		TransitionWithNote("Draft", "Review", "submit").
+		TransitionWithNote("Review", "Draft", "changes requested").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft --> Review : submit
+	//     Review --> Draft : changes requested
+}
+
+// ExampleDiagram_StartTransition draws the arrow from the entry point, which is
+// how a diagram says which state it begins in.
+func ExampleDiagram_StartTransition() {
+	_ = state.NewDiagram(os.Stdout).
+		StartTransition("Draft").
+		Transition("Draft", "Review").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     [*] --> Draft
+	//     Draft --> Review
+}
+
+// ExampleDiagram_StartTransitionWithNote labels the arrow from the entry point.
+func ExampleDiagram_StartTransitionWithNote() {
+	_ = state.NewDiagram(os.Stdout).
+		StartTransitionWithNote("Draft", "create").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     [*] --> Draft : create
+}
+
+// ExampleDiagram_EndTransition draws the arrow to the exit point.
+func ExampleDiagram_EndTransition() {
+	_ = state.NewDiagram(os.Stdout).
+		Transition("Draft", "Published").
+		EndTransition("Published").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft --> Published
+	//     Published --> [*]
+}
+
+// ExampleDiagram_EndTransitionWithNote labels the arrow to the exit point.
+func ExampleDiagram_EndTransitionWithNote() {
+	_ = state.NewDiagram(os.Stdout).
+		EndTransitionWithNote("Published", "archive").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Published --> [*] : archive
+}
+
+// ExampleDiagram_NoteRight puts a note beside a state.
+func ExampleDiagram_NoteRight() {
+	_ = state.NewDiagram(os.Stdout).
+		State("Draft", "Being written").
+		NoteRight("Draft", "Only the author can see it").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     note right of Draft : Only the author can see it
+}
+
+// ExampleDiagram_NoteLeft puts a note on the other side.
+func ExampleDiagram_NoteLeft() {
+	_ = state.NewDiagram(os.Stdout).
+		State("Draft", "Being written").
+		NoteLeft("Draft", "Only the author can see it").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     note left of Draft : Only the author can see it
+}
+
+// ExampleDiagram_NoteRightMultiLine puts a note of several lines beside a
+// state. Unlike the one line form, mermaid reads each line as text, so a colon
+// in one needs nothing done to it.
+func ExampleDiagram_NoteRightMultiLine() {
+	_ = state.NewDiagram(os.Stdout).
+		State("Draft", "Being written").
+		NoteRightMultiLine("Draft", "Only the author can see it.", "Visibility: private").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     note right of Draft
+	//         Only the author can see it.
+	//         Visibility: private
+	//     end note
+}
+
+// ExampleDiagram_NoteLeftMultiLine puts a note of several lines on the other
+// side.
+func ExampleDiagram_NoteLeftMultiLine() {
+	_ = state.NewDiagram(os.Stdout).
+		State("Draft", "Being written").
+		NoteLeftMultiLine("Draft", "Only the author can see it.", "Visibility: private").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     Draft : Being written
+	//     note left of Draft
+	//         Only the author can see it.
+	//         Visibility: private
+	//     end note
+}
+
+// ExampleDiagram_CompositeState opens a state holding states of its own. The
+// calls on the builder it returns belong to the inner diagram, and End closes
+// it and hands the outer one back.
+func ExampleDiagram_CompositeState() {
+	_ = state.NewDiagram(os.Stdout).
+		CompositeState("Review").
+		State("Reading", "A reviewer is reading it").
+		State("Commenting", "A reviewer is writing").
+		Transition("Reading", "Commenting").
+		End().
+		Transition("Draft", "Review").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state Review {
+	//         Reading : A reviewer is reading it
+	//         Commenting : A reviewer is writing
+	//         Reading --> Commenting
+	//     }
+	//     Draft --> Review
+}
+
+// ExampleCompositeStateBuilder shows what the composite state builder is: the
+// inner diagram, with the same calls as the outer one, until End.
+func ExampleCompositeStateBuilder() {
+	_ = state.NewDiagram(os.Stdout).
+		CompositeState("Review").
+		StartTransition("Reading").
+		State("Reading", "A reviewer is reading it").
+		Transition("Reading", "Commenting").
+		TransitionWithNote("Commenting", "Reading", "keep reading").
+		EndTransition("Commenting").
+		End().
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state Review {
+	//         [*] --> Reading
+	//         Reading : A reviewer is reading it
+	//         Reading --> Commenting
+	//         Commenting --> Reading : keep reading
+	//         Commenting --> [*]
+	//     }
+}
+
+// ExampleCompositeStateBuilder_End closes the composite state and returns the
+// outer diagram, so the chain carries on where it left off.
+func ExampleCompositeStateBuilder_End() {
+	_ = state.NewDiagram(os.Stdout).
+		CompositeState("Review").
+		State("Reading", "A reviewer is reading it").
+		End().
+		Transition("Draft", "Review").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state Review {
+	//         Reading : A reviewer is reading it
+	//     }
+	//     Draft --> Review
+}
+
+// ExampleCompositeStateBuilder_State declares a state inside the composite one.
+func ExampleCompositeStateBuilder_State() {
+	_ = state.NewDiagram(os.Stdout).
+		CompositeState("Review").
+		State("Reading", "A reviewer is reading it").
+		End().
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state Review {
+	//         Reading : A reviewer is reading it
+	//     }
+}
+
+// ExampleCompositeStateBuilder_Transition draws an arrow inside the composite
+// state.
+func ExampleCompositeStateBuilder_Transition() {
+	_ = state.NewDiagram(os.Stdout).
+		CompositeState("Review").
+		Transition("Reading", "Commenting").
+		End().
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state Review {
+	//         Reading --> Commenting
+	//     }
+}
+
+// ExampleCompositeStateBuilder_TransitionWithNote labels an arrow inside the
+// composite state.
+func ExampleCompositeStateBuilder_TransitionWithNote() {
+	_ = state.NewDiagram(os.Stdout).
+		CompositeState("Review").
+		TransitionWithNote("Reading", "Commenting", "found something").
+		End().
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state Review {
+	//         Reading --> Commenting : found something
+	//     }
+}
+
+// ExampleCompositeStateBuilder_StartTransition says which state the composite
+// one begins in.
+func ExampleCompositeStateBuilder_StartTransition() {
+	_ = state.NewDiagram(os.Stdout).
+		CompositeState("Review").
+		StartTransition("Reading").
+		End().
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state Review {
+	//         [*] --> Reading
+	//     }
+}
+
+// ExampleCompositeStateBuilder_EndTransition says which state the composite one
+// leaves from.
+func ExampleCompositeStateBuilder_EndTransition() {
+	_ = state.NewDiagram(os.Stdout).
+		CompositeState("Review").
+		EndTransition("Commenting").
+		End().
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state Review {
+	//         Commenting --> [*]
+	//     }
+}
+
+// ExampleDiagram_Fork splits one path into several that run at the same time.
+func ExampleDiagram_Fork() {
+	_ = state.NewDiagram(os.Stdout).
+		Fork("split").
+		Transition("Submitted", "split").
+		Transition("split", "Linting").
+		Transition("split", "Testing").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state split <<fork>>
+	//     Submitted --> split
+	//     split --> Linting
+	//     split --> Testing
+}
+
+// ExampleDiagram_Join brings the paths a fork split back together.
+func ExampleDiagram_Join() {
+	_ = state.NewDiagram(os.Stdout).
+		Join("rejoin").
+		Transition("Linting", "rejoin").
+		Transition("Testing", "rejoin").
+		Transition("rejoin", "Merged").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state rejoin <<join>>
+	//     Linting --> rejoin
+	//     Testing --> rejoin
+	//     rejoin --> Merged
+}
+
+// ExampleDiagram_Choice draws the point a path picks one way or the other.
+func ExampleDiagram_Choice() {
+	_ = state.NewDiagram(os.Stdout).
+		Choice("passed").
+		Transition("Testing", "passed").
+		TransitionWithNote("passed", "Merged", "yes").
+		TransitionWithNote("passed", "Failed", "no").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state passed <<choice>>
+	//     Testing --> passed
+	//     passed --> Merged : yes
+	//     passed --> Failed : no
+}
+
+// ExampleDiagram_Concurrent separates the regions of a state that run at the
+// same time.
+func ExampleDiagram_Concurrent() {
+	_ = state.NewDiagram(os.Stdout).
+		CompositeState("Running").
+		State("Linting", "go vet").
+		End().
+		Concurrent().
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     state Running {
+	//         Linting : go vet
+	//     }
+	//     ---
+}
+
+// ExampleDiagram_SetDirection says which way the diagram is laid out.
+func ExampleDiagram_SetDirection() {
+	_ = state.NewDiagram(os.Stdout).
+		SetDirection(state.DirectionLR).
+		Transition("Draft", "Review").
+		Build()
+
+	// Output:
+	// stateDiagram-v2
+	//     direction LR
+	//     Draft --> Review
+}
+
+// ExampleDirection shows the four ways a diagram can be laid out.
+func ExampleDirection() {
+	for _, direction := range []state.Direction{
+		state.DirectionTB, state.DirectionBT, state.DirectionLR, state.DirectionRL,
+	} {
+		_ = state.NewDiagram(os.Stdout).
+			SetDirection(direction).
+			Transition("Draft", "Review").
+			Build()
+		fmt.Println()
+	}
+
+	// Output:
+	// stateDiagram-v2
+	//     direction TB
+	//     Draft --> Review
+	// stateDiagram-v2
+	//     direction BT
+	//     Draft --> Review
+	// stateDiagram-v2
+	//     direction LR
+	//     Draft --> Review
+	// stateDiagram-v2
+	//     direction RL
+	//     Draft --> Review
 }

--- a/mermaid/timeline/examples_test.go
+++ b/mermaid/timeline/examples_test.go
@@ -3,6 +3,7 @@
 package timeline_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -41,4 +42,179 @@ func ExampleDiagram() {
 	//         2004 : Facebook : Google
 	//         2005 : YouTube : Reddit
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every timeline has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = timeline.NewDiagram(os.Stdout).
+		Section("2024").Period("Q1", "Kickoff").
+		Build()
+
+	// Output:
+	// timeline
+	//     section 2024
+	//         Q1 : Kickoff
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := timeline.NewDiagram(io.Discard).
+		Section("2024").Period("Q1", "Kickoff").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// timeline
+	//     section 2024
+	//         Q1 : Kickoff
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := timeline.NewDiagram(nil).
+		Section("2024").Period("Q1", "Kickoff").
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := timeline.NewDiagram(io.Discard).
+		Period("Q1", "Kickoff")
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: <nil>
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = timeline.NewDiagram(os.Stdout).
+		Section("2024").Period("Q1", "Kickoff").
+		LF().
+		Section("2024").Period("Q1", "Kickoff").
+		Build()
+
+	// Output:
+	// timeline
+	//     section 2024
+	//         Q1 : Kickoff
+	//
+	//     section 2024
+	//         Q1 : Kickoff
+}
+
+// ExampleDiagram_full shows a timeline built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := timeline.NewDiagram(io.Discard).
+		Section("2024").Period("Q1", "Kickoff").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// timeline
+	//     section 2024
+	//         Q1 : Kickoff
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []timeline.Option{timeline.WithTitle("Overview")}
+
+	_ = timeline.NewDiagram(os.Stdout, options...).
+		Section("2024").Period("Q1", "Kickoff").
+		Build()
+
+	// Output:
+	// timeline
+	//     title Overview
+	//     section 2024
+	//         Q1 : Kickoff
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = timeline.NewDiagram(os.Stdout, timeline.WithTitle("Overview")).
+		Section("2024").Period("Q1", "Kickoff").
+		Build()
+
+	// Output:
+	// timeline
+	//     title Overview
+	//     section 2024
+	//         Q1 : Kickoff
+}
+
+// ExampleDiagram_Section groups the periods that follow it. A timeline needs a
+// section before anything else, and a period added without one is reported
+// from Build rather than drawn in the wrong place.
+func ExampleDiagram_Section() {
+	_ = timeline.NewDiagram(os.Stdout).
+		Section("2024").
+		Period("Q1", "Kickoff").
+		Section("2025").
+		Period("Q1", "Launch").
+		Build()
+
+	// Output:
+	// timeline
+	//     section 2024
+	//         Q1 : Kickoff
+	//     section 2025
+	//         Q1 : Launch
+}
+
+// ExampleDiagram_Period adds a point on the timeline with the events that
+// happened in it. The events are optional, and each is drawn beside the period
+// rather than under it.
+func ExampleDiagram_Period() {
+	_ = timeline.NewDiagram(os.Stdout).
+		Section("2024").
+		Period("Q1", "Kickoff", "Design review").
+		Period("Q2").
+		Build()
+
+	// Output:
+	// timeline
+	//     section 2024
+	//         Q1 : Kickoff : Design review
+	//         Q2
+}
+
+// ExampleDiagram_Event adds an event to the period added last, which is how a
+// long list of them stays readable in the chain.
+func ExampleDiagram_Event() {
+	_ = timeline.NewDiagram(os.Stdout).
+		Section("2024").
+		Period("Q1").
+		Event("Kickoff").
+		Event("Design review").
+		Build()
+
+	// Output:
+	// timeline
+	//     section 2024
+	//         Q1 : Kickoff : Design review
 }

--- a/mermaid/treemap/examples_test.go
+++ b/mermaid/treemap/examples_test.go
@@ -3,6 +3,7 @@
 package treemap_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -47,4 +48,188 @@ func ExampleDiagram() {
 	// "Marketing"
 	//     "Ads": 800
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every treemap has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = treemap.NewDiagram(os.Stdout).
+		Section("Ops").Leaf("Salaries", 1200).
+		Build()
+
+	// Output:
+	// treemap-beta
+	// "Ops"
+	//     "Salaries": 1200
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := treemap.NewDiagram(io.Discard).
+		Section("Ops").Leaf("Salaries", 1200).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// treemap-beta
+	// "Ops"
+	//     "Salaries": 1200
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := treemap.NewDiagram(nil).
+		Section("Ops").Leaf("Salaries", 1200).
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := treemap.NewDiagram(io.Discard).
+		Parent()
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: Parent was called at the top level; there is nothing to go up to
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = treemap.NewDiagram(os.Stdout).
+		Section("Ops").Leaf("Salaries", 1200).
+		LF().
+		Section("Ops").Leaf("Salaries", 1200).
+		Build()
+
+	// Output:
+	// treemap-beta
+	// "Ops"
+	//     "Salaries": 1200
+	//
+	//     "Ops"
+	//         "Salaries": 1200
+}
+
+// ExampleDiagram_full shows a treemap built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := treemap.NewDiagram(io.Discard).
+		Section("Ops").Leaf("Salaries", 1200).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// treemap-beta
+	// "Ops"
+	//     "Salaries": 1200
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []treemap.Option{treemap.WithTitle("Overview")}
+
+	_ = treemap.NewDiagram(os.Stdout, options...).
+		Section("Ops").Leaf("Salaries", 1200).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// treemap-beta
+	// "Ops"
+	//     "Salaries": 1200
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = treemap.NewDiagram(os.Stdout, treemap.WithTitle("Overview")).
+		Section("Ops").Leaf("Salaries", 1200).
+		Build()
+
+	// Output:
+	// ---
+	// title: "Overview"
+	// ---
+	// treemap-beta
+	// "Ops"
+	//     "Salaries": 1200
+}
+
+// ExampleDiagram_Section opens a level of the hierarchy. Everything added until
+// Parent belongs to it, and a section carries no value of its own: mermaid
+// gives it the sum of what it holds.
+func ExampleDiagram_Section() {
+	_ = treemap.NewDiagram(os.Stdout).
+		Section("Ops").
+		Leaf("Salaries", 1200).
+		Parent().
+		Section("Marketing").
+		Leaf("Ads", 800).
+		Build()
+
+	// Output:
+	// treemap-beta
+	// "Ops"
+	//     "Salaries": 1200
+	// "Marketing"
+	//     "Ads": 800
+}
+
+// ExampleDiagram_Leaf puts a value in the current level. A leaf is what a
+// treemap actually draws: the area it gets is its value against the whole.
+func ExampleDiagram_Leaf() {
+	_ = treemap.NewDiagram(os.Stdout).
+		Leaf("Salaries", 1200).
+		Leaf("Travel", 300).
+		Build()
+
+	// Output:
+	// treemap-beta
+	// "Salaries": 1200
+	// "Travel": 300
+}
+
+// ExampleDiagram_Parent leaves the section opened last. Calling it at the top
+// level is an error rather than a silent no-op, because a chain that has gone
+// up more often than down is not the diagram its author meant.
+func ExampleDiagram_Parent() {
+	_ = treemap.NewDiagram(os.Stdout).
+		Section("Ops").
+		Section("Cloud").
+		Leaf("Compute", 400).
+		Parent().
+		Leaf("Travel", 300).
+		Parent().
+		Leaf("Everything else", 100).
+		Build()
+
+	// Output:
+	// treemap-beta
+	// "Ops"
+	//     "Cloud"
+	//         "Compute": 400
+	//     "Travel": 300
+	// "Everything else": 100
 }

--- a/mermaid/userjourney/examples_test.go
+++ b/mermaid/userjourney/examples_test.go
@@ -175,7 +175,7 @@ func ExampleWithTitle() {
 func ExampleDiagram_Section() {
 	_ = userjourney.NewDiagram(os.Stdout).
 		Section("Browse").
-		Task("Search the catalogue", userjourney.ScoreSatisfied, "Customer").
+		Task("Search the catalog", userjourney.ScoreSatisfied, "Customer").
 		Section("Checkout").
 		Task("Pay", userjourney.ScoreNeutral, "Customer", "Payment Service").
 		Build()
@@ -183,7 +183,7 @@ func ExampleDiagram_Section() {
 	// Output:
 	// journey
 	//     section Browse
-	//         Search the catalogue: 4: Customer
+	//         Search the catalog: 4: Customer
 	//     section Checkout
 	//         Pay: 3: Customer, Payment Service
 }
@@ -213,7 +213,7 @@ func ExampleDiagram_TaskIn() {
 	_ = userjourney.NewDiagram(os.Stdout).
 		Section("Browse").
 		Section("Checkout").
-		TaskIn("Browse", "Search the catalogue", userjourney.ScoreSatisfied, "Customer").
+		TaskIn("Browse", "Search the catalog", userjourney.ScoreSatisfied, "Customer").
 		TaskIn("Checkout", "Pay", userjourney.ScoreNeutral, "Customer").
 		Build()
 
@@ -222,7 +222,7 @@ func ExampleDiagram_TaskIn() {
 	//     section Browse
 	//     section Checkout
 	//     section Browse
-	//         Search the catalogue: 4: Customer
+	//         Search the catalog: 4: Customer
 	//     section Checkout
 	//         Pay: 3: Customer
 }

--- a/mermaid/userjourney/examples_test.go
+++ b/mermaid/userjourney/examples_test.go
@@ -3,6 +3,7 @@
 package userjourney_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -44,4 +45,206 @@ func ExampleDiagram() {
 	//         Enter shipping details: 3: Customer
 	//         Complete payment: 4: Customer, Payment Service
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every user journey has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = userjourney.NewDiagram(os.Stdout).
+		Section("Checkout").Task("Add to basket", userjourney.ScoreSatisfied, "Customer").
+		Build()
+
+	// Output:
+	// journey
+	//     section Checkout
+	//         Add to basket: 4: Customer
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := userjourney.NewDiagram(io.Discard).
+		Section("Checkout").Task("Add to basket", userjourney.ScoreSatisfied, "Customer").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// journey
+	//     section Checkout
+	//         Add to basket: 4: Customer
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := userjourney.NewDiagram(nil).
+		Section("Checkout").Task("Add to basket", userjourney.ScoreSatisfied, "Customer").
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := userjourney.NewDiagram(io.Discard).
+		Task("no section yet", userjourney.ScoreSatisfied)
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: task "no section yet" requires a section; call Section first
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = userjourney.NewDiagram(os.Stdout).
+		Section("Checkout").Task("Add to basket", userjourney.ScoreSatisfied, "Customer").
+		LF().
+		Section("Checkout").Task("Add to basket", userjourney.ScoreSatisfied, "Customer").
+		Build()
+
+	// Output:
+	// journey
+	//     section Checkout
+	//         Add to basket: 4: Customer
+	//
+	//     section Checkout
+	//         Add to basket: 4: Customer
+}
+
+// ExampleDiagram_full shows a user journey built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := userjourney.NewDiagram(io.Discard).
+		Section("Checkout").Task("Add to basket", userjourney.ScoreSatisfied, "Customer").
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// journey
+	//     section Checkout
+	//         Add to basket: 4: Customer
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []userjourney.Option{userjourney.WithTitle("Overview")}
+
+	_ = userjourney.NewDiagram(os.Stdout, options...).
+		Section("Checkout").Task("Add to basket", userjourney.ScoreSatisfied, "Customer").
+		Build()
+
+	// Output:
+	// journey
+	//     title Overview
+	//     section Checkout
+	//         Add to basket: 4: Customer
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = userjourney.NewDiagram(os.Stdout, userjourney.WithTitle("Overview")).
+		Section("Checkout").Task("Add to basket", userjourney.ScoreSatisfied, "Customer").
+		Build()
+
+	// Output:
+	// journey
+	//     title Overview
+	//     section Checkout
+	//         Add to basket: 4: Customer
+}
+
+// ExampleDiagram_Section starts a stage of the journey. A journey needs one
+// before any task, and a task added without one is reported from Build.
+func ExampleDiagram_Section() {
+	_ = userjourney.NewDiagram(os.Stdout).
+		Section("Browse").
+		Task("Search the catalogue", userjourney.ScoreSatisfied, "Customer").
+		Section("Checkout").
+		Task("Pay", userjourney.ScoreNeutral, "Customer", "Payment Service").
+		Build()
+
+	// Output:
+	// journey
+	//     section Browse
+	//         Search the catalogue: 4: Customer
+	//     section Checkout
+	//         Pay: 3: Customer, Payment Service
+}
+
+// ExampleDiagram_Task adds a step to the current section, with how the actors
+// felt about it and who was involved. The actors are optional.
+func ExampleDiagram_Task() {
+	_ = userjourney.NewDiagram(os.Stdout).
+		Section("Checkout").
+		Task("Add to basket", userjourney.ScoreVerySatisfied, "Customer").
+		Task("Enter card details", userjourney.ScoreDissatisfied, "Customer", "Payment Service").
+		Task("Confirm", userjourney.ScoreSatisfied).
+		Build()
+
+	// Output:
+	// journey
+	//     section Checkout
+	//         Add to basket: 5: Customer
+	//         Enter card details: 2: Customer, Payment Service
+	//         Confirm: 4
+}
+
+// ExampleDiagram_TaskIn adds a step to a section named outright, which saves
+// switching back and forth when the steps of two sections are interleaved in
+// the calling code.
+func ExampleDiagram_TaskIn() {
+	_ = userjourney.NewDiagram(os.Stdout).
+		Section("Browse").
+		Section("Checkout").
+		TaskIn("Browse", "Search the catalogue", userjourney.ScoreSatisfied, "Customer").
+		TaskIn("Checkout", "Pay", userjourney.ScoreNeutral, "Customer").
+		Build()
+
+	// Output:
+	// journey
+	//     section Browse
+	//     section Checkout
+	//     section Browse
+	//         Search the catalogue: 4: Customer
+	//     section Checkout
+	//         Pay: 3: Customer
+}
+
+// ExampleScore shows the five sentiments a task can carry. mermaid draws a
+// happier face for a higher one, and the numbers it writes are 1 to 5.
+func ExampleScore() {
+	_ = userjourney.NewDiagram(os.Stdout).
+		Section("Checkout").
+		Task("Very dissatisfied", userjourney.ScoreVeryDissatisfied, "Customer").
+		Task("Dissatisfied", userjourney.ScoreDissatisfied, "Customer").
+		Task("Neutral", userjourney.ScoreNeutral, "Customer").
+		Task("Satisfied", userjourney.ScoreSatisfied, "Customer").
+		Task("Very satisfied", userjourney.ScoreVerySatisfied, "Customer").
+		Build()
+
+	// Output:
+	// journey
+	//     section Checkout
+	//         Very dissatisfied: 1: Customer
+	//         Dissatisfied: 2: Customer
+	//         Neutral: 3: Customer
+	//         Satisfied: 4: Customer
+	//         Very satisfied: 5: Customer
 }

--- a/mermaid/xychart/examples_test.go
+++ b/mermaid/xychart/examples_test.go
@@ -3,6 +3,7 @@
 package xychart_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -40,4 +41,292 @@ func ExampleDiagram() {
 	//     bar [25, 40, 60, 80, 70, 90]
 	//     line [30, 50, 70, 85, 75, 95]
 	// ```
+}
+
+// ExampleNewDiagram shows the shape every xy chart has: a writer, a chain of
+// calls, and Build.
+func ExampleNewDiagram() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisLabelsWithTitle("Month", "Jan", "Feb").Bar(10, 20).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis Month [Jan, Feb]
+	//     bar [10, 20]
+}
+
+// ExampleDiagram_String returns the diagram without needing a writer, which is
+// how it is handed to a markdown code block.
+func ExampleDiagram_String() {
+	diagram := xychart.NewDiagram(io.Discard).
+		XAxisLabelsWithTitle("Month", "Jan", "Feb").Bar(10, 20).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ```mermaid
+	// xychart
+	//     x-axis Month [Jan, Feb]
+	//     bar [10, 20]
+	// ```
+}
+
+// ExampleDiagram_Build writes the diagram and reports the first error the chain
+// recorded. Nothing in the chain panics on bad input, so one check at the end
+// is enough.
+func ExampleDiagram_Build() {
+	err := xychart.NewDiagram(nil).
+		XAxisLabelsWithTitle("Month", "Jan", "Feb").Bar(10, 20).
+		Build()
+	fmt.Println("error:", err)
+
+	// Output:
+	// error: output writer must not be nil
+}
+
+// ExampleDiagram_Error reports the same error Build does, for code that wants
+// to look before writing anything.
+func ExampleDiagram_Error() {
+	d := xychart.NewDiagram(io.Discard).
+		XAxisRange(10, 0)
+	fmt.Println("error:", d.Error())
+
+	// Output:
+	// error: x-axis range requires min to be less than max
+}
+
+// ExampleDiagram_LF adds a blank line to the diagram body.
+func ExampleDiagram_LF() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisLabelsWithTitle("Month", "Jan", "Feb").Bar(10, 20).
+		LF().
+		XAxisLabelsWithTitle("Month", "Jan", "Feb").Bar(10, 20).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis Month [Jan, Feb]
+	//     bar [10, 20]
+	//
+	//     x-axis Month [Jan, Feb]
+	//     bar [10, 20]
+}
+
+// ExampleDiagram_full shows a xy chart built end to end and put into a markdown
+// document, which is what this package exists for.
+func ExampleDiagram_full() {
+	diagram := xychart.NewDiagram(io.Discard).
+		XAxisLabelsWithTitle("Month", "Jan", "Feb").Bar(10, 20).
+		String()
+
+	_ = md.NewMarkdown(os.Stdout).
+		H2("Diagram").
+		CodeBlocks(md.SyntaxHighlightMermaid, diagram).
+		Build()
+
+	// Output:
+	// ## Diagram
+	// ```mermaid
+	// xychart
+	//     x-axis Month [Jan, Feb]
+	//     bar [10, 20]
+	// ```
+}
+
+// ExampleOption shows what an Option is: a function that changes how the
+// diagram is written, passed to NewDiagram.
+func ExampleOption() {
+	options := []xychart.Option{xychart.WithTitle("Overview")}
+
+	_ = xychart.NewDiagram(os.Stdout, options...).
+		XAxisLabelsWithTitle("Month", "Jan", "Feb").Bar(10, 20).
+		Build()
+
+	// Output:
+	// xychart
+	//     title "Overview"
+	//     x-axis Month [Jan, Feb]
+	//     bar [10, 20]
+}
+
+// ExampleWithTitle sets the title the diagram is drawn with.
+func ExampleWithTitle() {
+	_ = xychart.NewDiagram(os.Stdout, xychart.WithTitle("Overview")).
+		XAxisLabelsWithTitle("Month", "Jan", "Feb").Bar(10, 20).
+		Build()
+
+	// Output:
+	// xychart
+	//     title "Overview"
+	//     x-axis Month [Jan, Feb]
+	//     bar [10, 20]
+}
+
+// ExampleDiagram_XAxisLabels names the points along the x axis, for data that
+// is counted by category rather than measured on a scale.
+func ExampleDiagram_XAxisLabels() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisLabels("Jan", "Feb", "Mar").
+		Bar(10, 20, 30).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis [Jan, Feb, Mar]
+	//     bar [10, 20, 30]
+}
+
+// ExampleDiagram_XAxisLabelsWithTitle names the points and the axis itself.
+func ExampleDiagram_XAxisLabelsWithTitle() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisLabelsWithTitle("Month", "Jan", "Feb", "Mar").
+		Bar(10, 20, 30).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis Month [Jan, Feb, Mar]
+	//     bar [10, 20, 30]
+}
+
+// ExampleDiagram_XAxisRange measures the x axis on a scale instead, which is
+// what a chart of a continuous quantity needs.
+func ExampleDiagram_XAxisRange() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisRange(0, 100).
+		Line(10, 20, 30).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis 0 --> 100
+	//     line [10, 20, 30]
+}
+
+// ExampleDiagram_XAxisRangeWithTitle measures the x axis and names it.
+func ExampleDiagram_XAxisRangeWithTitle() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisRangeWithTitle("Load", 0, 100).
+		Line(10, 20, 30).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis Load 0 --> 100
+	//     line [10, 20, 30]
+}
+
+// ExampleDiagram_YAxisRange sets the scale the values are drawn against.
+// Without it mermaid picks one from the data, so two charts of different data
+// cannot be compared by eye.
+func ExampleDiagram_YAxisRange() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisLabels("Jan", "Feb").
+		YAxisRange(0, 100).
+		Bar(10, 20).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis [Jan, Feb]
+	//     y-axis 0 --> 100
+	//     bar [10, 20]
+}
+
+// ExampleDiagram_YAxisRangeWithTitle sets the scale and names it.
+func ExampleDiagram_YAxisRangeWithTitle() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisLabels("Jan", "Feb").
+		YAxisRangeWithTitle("Revenue", 0, 100).
+		Bar(10, 20).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis [Jan, Feb]
+	//     y-axis Revenue 0 --> 100
+	//     bar [10, 20]
+}
+
+// ExampleDiagram_Bar draws the values as columns.
+func ExampleDiagram_Bar() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisLabels("Jan", "Feb", "Mar").
+		Bar(10, 20, 30).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis [Jan, Feb, Mar]
+	//     bar [10, 20, 30]
+}
+
+// ExampleDiagram_Line draws the values as a line, and a chart may carry both a
+// line and bars.
+func ExampleDiagram_Line() {
+	_ = xychart.NewDiagram(os.Stdout).
+		XAxisLabels("Jan", "Feb", "Mar").
+		Bar(10, 20, 30).
+		Line(15, 25, 35).
+		Build()
+
+	// Output:
+	// xychart
+	//     x-axis [Jan, Feb, Mar]
+	//     bar [10, 20, 30]
+	//     line [15, 25, 35]
+}
+
+// ExampleWithHorizontal turns the chart on its side, so the categories run down
+// the page. It is the readable choice when the labels are long.
+func ExampleWithHorizontal() {
+	_ = xychart.NewDiagram(os.Stdout, xychart.WithHorizontal()).
+		XAxisLabels("Jan", "Feb").
+		Bar(10, 20).
+		Build()
+
+	// Output:
+	// xychart horizontal
+	//     x-axis [Jan, Feb]
+	//     bar [10, 20]
+}
+
+// ExampleWithOrientation says which way the chart runs, for code that decides
+// between the two rather than picking one outright.
+func ExampleWithOrientation() {
+	_ = xychart.NewDiagram(os.Stdout, xychart.WithOrientation(xychart.OrientationHorizontal)).
+		XAxisLabels("Jan", "Feb").
+		Bar(10, 20).
+		Build()
+
+	// Output:
+	// xychart horizontal
+	//     x-axis [Jan, Feb]
+	//     bar [10, 20]
+}
+
+// ExampleOrientation shows the two directions a chart can run in.
+func ExampleOrientation() {
+	for _, orientation := range []xychart.Orientation{
+		xychart.OrientationVertical,
+		xychart.OrientationHorizontal,
+	} {
+		_ = xychart.NewDiagram(os.Stdout, xychart.WithOrientation(orientation)).
+			XAxisLabels("Jan").
+			Bar(10).
+			Build()
+		fmt.Println()
+	}
+
+	// Output:
+	// xychart
+	//     x-axis [Jan]
+	//     bar [10]
+	// xychart horizontal
+	//     x-axis [Jan]
+	//     bar [10]
 }


### PR DESCRIPTION
Closes #131 (task 3, the mermaid half; the root package landed in #174).

## What this covers

All twenty-two subpackages. Each had **one** example — of a whole diagram — for between six and sixty-six exported symbols. pkg.go.dev puts an example under the symbol it is named for, so a reader looking at `Leaf`, `Curve`, `Link`, `Sibling`, `Next`, `BoundaryEnd` or `WithTaskPriority` saw nothing at all.

**673 examples** now run across the module, every one output-verified.

## Not filler

Each example says something the signature does not:

- a treemap `Section` carries no value of its own — mermaid gives it the sum of what it holds
- a sankey node exists because a link names it; there is nothing else to declare
- a mindmap `Child` descends a level and `Sibling` does not
- a packet `Field` takes a range inclusive at both ends, `Next` takes a width
- a gantt task comes in four states × critical × with-an-id, and the *names* do not say that an active one is drawn hatched and a done one filled in
- a flowchart `AsymmetricNode` is a flag and a `RhombusNode` is how a decision is drawn — you cannot tell from the method name
- an `InvisibleLink` pushes a diagram into the layout its author wants without saying anything untrue about the flow
- a C4 boundary is a **pair** of calls, and the pairing is invisible in the signature
- a state `CompositeState` returns an *inner* diagram and `End` hands the outer one back — the one place in this library where the chain changes what it is building halfway through
- an `arch` title takes only `[A-Za-z0-9_ ]`, mermaid refuses the whole diagram otherwise, and there is no escape to reach for

The examples every builder shares — `Build`, `Error`, `LF`, `String`, `Option`, `WithTitle` — are worded identically across all twenty-two. They do the same thing, and a reader moving between packages should not have to work out whether different wording means different behavior.

## Two bugs the audit caught, worth reporting

An example that builds nothing prints nothing, and an **empty `// Output:` block matches that happily** — so it passes while documenting nothing.

1. The `requirement` examples called `Requirement` with an id alone. That builder needs all four fields — id, text, risk, verify method — and records an error otherwise, writing no block at all. Twenty examples passed while producing empty documents.
2. The `mindmap` `LF` example called `Root` twice, which records "root node is already defined".

`TestEveryExportedSymbolHasAnExample` found both, because it requires a **non-empty** output before counting an example as documenting its symbol — the same rule godoc applies. Fixed, and the requirement examples now show the four-field requirement, which is the thing about that package a reader most needs to see.

I also swept for empty output blocks across the module: none remain.

## The audit now lists every package

It started at `["."]`. It is now `mermaid/*` plus the root, so a new subpackage or a new exported symbol arriving without an example fails the build.

## Verification

- `go test ./...` passes; 673 examples, all with filled `// Output:` blocks captured from actual runs rather than written from memory.
- `golangci-lint run ./...` reports 0 issues.
- `TestEveryExportedSymbolHasAnExample` reports nothing missing across all 23 packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive, runnable examples for creating and rendering Mermaid diagrams across the supported chart and diagram types.
  * Documented configuration options, styling, relationships, layouts, formatting, Markdown integration, and validation/error handling.
  * Examples now demonstrate expected Mermaid output for common API features.

* **Tests**
  * Expanded automated coverage to verify examples across all Mermaid subpackages, not only the root package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->