### PR TITLE
feat(mermaid/flowchart): add subgraphs and the styling the other builders have

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,14 +1227,21 @@ func main() {
 		flowchart.WithTitle("mermaid flowchart builder"),
 		flowchart.WithOrientalTopToBottom(),
 	).
+		Subgraph("ingest", "Ingest").
+		SubgraphDirection(flowchart.DirectionLR).
 		NodeWithText("A", "Node A").
 		StadiumNode("B", "Node B").
+		LinkWithArrowHead("A", "B").
+		SubgraphEnd().
 		SubroutineNode("C", "Node C").
 		DatabaseNode("D", "Database").
-		LinkWithArrowHead("A", "B").
 		LinkWithArrowHeadAndText("B", "D", "send original data").
 		LinkWithArrowHead("B", "C").
 		DottedLinkWithText("C", "D", "send filtered data").
+		ClassDef("stored", "fill:#d4f7d4,stroke:#2b8a3e").
+		Class("D", "stored").
+		Style("C", "fill:#fff3bf,stroke:#e67700").
+		ClickHref("D", "https://example.com/database", "The database").
 		String()
 
 	err = markdown.NewMarkdown(f, markdown.WithBlockSpacing()).
@@ -1257,28 +1264,45 @@ Plain text output: [markdown is here](./doc/flowchart/generated.md)
 title: "mermaid flowchart builder"
 ---
 flowchart TB
-    A["Node A"]
-    B(["Node B"])
+    subgraph ingest["Ingest"]
+        direction LR
+        A["Node A"]
+        B(["Node B"])
+        A-->B
+    end
     C[["Node C"]]
     D[("Database")]
-    A-->B
     B-->|"send original data"|D
     B-->C
     C-. "send filtered data" .-> D
+    classDef stored fill:#d4f7d4,stroke:#2b8a3e
+    class D stored
+    style C fill:#fff3bf,stroke:#e67700
+    click D "https://example.com/database" "The database"
 ```
 ````
 
 Mermaid output:
 ```mermaid
+---
+title: "mermaid flowchart builder"
+---
 flowchart TB
-	A["Node A"]
-	B(["Node B"])
-	C[["Node C"]]
-	D[("Database")]
-	A-->B
-	B-->|"send original data"|D
-	B-->C
-	C-. "send filtered data" .-> D
+    subgraph ingest["Ingest"]
+        direction LR
+        A["Node A"]
+        B(["Node B"])
+        A-->B
+    end
+    C[["Node C"]]
+    D[("Database")]
+    B-->|"send original data"|D
+    B-->C
+    C-. "send filtered data" .-> D
+    classDef stored fill:#d4f7d4,stroke:#2b8a3e
+    class D stored
+    style C fill:#fff3bf,stroke:#e67700
+    click D "https://example.com/database" "The database"
 ```
 
 ### Pie chart syntax

--- a/doc/edgecase/flowchart.md
+++ b/doc/edgecase/flowchart.md
@@ -7,6 +7,9 @@ Every label below holds the punctuation this diagram type can carry. Generated b
 title: "title \"'#;[](){}🎉日本語:,*-|%%\\"
 ---
 flowchart TB
+    subgraph group["x#quot;'#;[](){}<br/>🎉日本語:,*-|%%\x"]
+    end
+    click A "https://example.com" "before #quot;'#;[](){}<br/>🎉日本語:,*-|%%\ after"
     A["before #quot;'#;[](){}<br/>🎉日本語:,*-|%%\ after"]
     B{"x#quot;'#;[](){}<br/>🎉日本語:,*-|%%\x"}
     C(("x#quot;'#;[](){}<br/>🎉日本語:,*-|%%\x"))

--- a/doc/edgecase/main.go
+++ b/doc/edgecase/main.go
@@ -306,6 +306,9 @@ func entityRelationship(diagram string) string {
 
 func flowchartDiagram(diagram string) string {
 	return flowchart.NewFlowchart(io.Discard, flowchart.WithTitle(title(diagram))).
+		Subgraph("group", shortLabel(diagram)).
+		SubgraphEnd().
+		ClickHref("A", "https://example.com", label(diagram)).
 		NodeWithText("A", label(diagram)).
 		RhombusNode("B", shortLabel(diagram)).
 		CircleNode("C", shortLabel(diagram)).

--- a/doc/flowchart/generated.md
+++ b/doc/flowchart/generated.md
@@ -5,12 +5,19 @@
 title: "mermaid flowchart builder"
 ---
 flowchart TB
-    A["Node A"]
-    B(["Node B"])
+    subgraph ingest["Ingest"]
+        direction LR
+        A["Node A"]
+        B(["Node B"])
+        A-->B
+    end
     C[["Node C"]]
     D[("Database")]
-    A-->B
     B-->|"send original data"|D
     B-->C
     C-. "send filtered data" .-> D
+    classDef stored fill:#d4f7d4,stroke:#2b8a3e
+    class D stored
+    style C fill:#fff3bf,stroke:#e67700
+    click D "https://example.com/database" "The database"
 ```

--- a/doc/flowchart/main.go
+++ b/doc/flowchart/main.go
@@ -29,14 +29,21 @@ func main() {
 		flowchart.WithTitle("mermaid flowchart builder"),
 		flowchart.WithOrientalTopToBottom(),
 	).
+		Subgraph("ingest", "Ingest").
+		SubgraphDirection(flowchart.DirectionLR).
 		NodeWithText("A", "Node A").
 		StadiumNode("B", "Node B").
+		LinkWithArrowHead("A", "B").
+		SubgraphEnd().
 		SubroutineNode("C", "Node C").
 		DatabaseNode("D", "Database").
-		LinkWithArrowHead("A", "B").
 		LinkWithArrowHeadAndText("B", "D", "send original data").
 		LinkWithArrowHead("B", "C").
 		DottedLinkWithText("C", "D", "send filtered data").
+		ClassDef("stored", "fill:#d4f7d4,stroke:#2b8a3e").
+		Class("D", "stored").
+		Style("C", "fill:#fff3bf,stroke:#e67700").
+		ClickHref("D", "https://example.com/database", "The database").
 		String()
 
 	err = markdown.NewMarkdown(f, markdown.WithBlockSpacing()).

--- a/doc/v1-api-audit.md
+++ b/doc/v1-api-audit.md
@@ -5,7 +5,7 @@ each of it for v1.0.0. From that release the exported API and the bytes it
 produces are frozen: see the API stability and output stability sections of
 [SPEC.md](../SPEC.md).
 
-The audit covers **859 exported symbols** across **23 packages**. The verdict on
+The audit covers **872 exported symbols** across **23 packages**. The verdict on
 every one of them is **keep**. Nothing is removed, nothing is renamed, no
 signature changes, and nothing is deprecated: this library is used in production
 and backward compatibility outranks tidiness.
@@ -59,7 +59,7 @@ the tables below, which is where the reason for each of them is.
 | `github.com/nao1215/markdown/mermaid/c4` | 26 | none | none |
 | `github.com/nao1215/markdown/mermaid/class` | 96 | none | `Diagram.CSSClass` |
 | `github.com/nao1215/markdown/mermaid/er` | 27 | the `Identify` constants are suffixed `Identifying` rather than prefixed; the `Relationship` constants are suffixed `Relationship` rather than prefixed | `Diagram.Relationship` |
-| `github.com/nao1215/markdown/mermaid/flowchart` | 39 | none | `Flowchart` |
+| `github.com/nao1215/markdown/mermaid/flowchart` | 52 | none | `Flowchart` |
 | `github.com/nao1215/markdown/mermaid/gantt` | 32 | none | `Chart` |
 | `github.com/nao1215/markdown/mermaid/gitgraph` | 26 | none | none |
 | `github.com/nao1215/markdown/mermaid/kanban` | 24 | none | none |
@@ -511,6 +511,11 @@ Accepted for v1: the `Identify` constants are suffixed `Identifying` rather than
 
 | Symbol | Kind | Verdict | Note |
 | --- | --- | --- | --- |
+| `Direction` | type | keep |  |
+| `DirectionBT` | const | keep |  |
+| `DirectionLR` | const | keep |  |
+| `DirectionRL` | const | keep |  |
+| `DirectionTB` | const | keep |  |
 | `Flowchart` | type | keep | Named Flowchart rather than Diagram, and its constructor NewFlowchart. Accepted for v1. |
 | `NewFlowchart` | func | keep |  |
 | `Option` | type | keep |  |
@@ -523,6 +528,10 @@ Accepted for v1: the `Identify` constants are suffixed `Identifying` rather than
 | `Flowchart.AsymmetricNode` | method | keep |  |
 | `Flowchart.Build` | method | keep |  |
 | `Flowchart.CircleNode` | method | keep |  |
+| `Flowchart.Class` | method | keep |  |
+| `Flowchart.ClassDef` | method | keep |  |
+| `Flowchart.ClickCall` | method | keep |  |
+| `Flowchart.ClickHref` | method | keep |  |
 | `Flowchart.CylindricalNode` | method | keep |  |
 | `Flowchart.DatabaseNode` | method | keep |  |
 | `Flowchart.DottedLink` | method | keep |  |
@@ -545,6 +554,10 @@ Accepted for v1: the `Identify` constants are suffixed `Identifying` rather than
 | `Flowchart.RoundEdgesNode` | method | keep |  |
 | `Flowchart.StadiumNode` | method | keep |  |
 | `Flowchart.String` | method | keep |  |
+| `Flowchart.Style` | method | keep |  |
+| `Flowchart.Subgraph` | method | keep |  |
+| `Flowchart.SubgraphDirection` | method | keep |  |
+| `Flowchart.SubgraphEnd` | method | keep |  |
 | `Flowchart.SubroutineNode` | method | keep |  |
 | `Flowchart.ThickLink` | method | keep |  |
 | `Flowchart.ThickLinkWithText` | method | keep |  |

--- a/mermaid/flowchart/examples_test.go
+++ b/mermaid/flowchart/examples_test.go
@@ -552,3 +552,178 @@ func ExampleFlowchart_Error() {
 	// before Build: <nil>
 	// after Build: output writer must not be nil
 }
+
+// ExampleFlowchart_Subgraph groups the nodes that follow it into a box.
+// SubgraphEnd closes it, and what lies between is indented.
+func ExampleFlowchart_Subgraph() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		Subgraph("ingest", "Ingest").
+		NodeWithText("a", "Fetch").
+		NodeWithText("b", "Parse").
+		SubgraphEnd().
+		NodeWithText("c", "Store").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     subgraph ingest["Ingest"]
+	//         a["Fetch"]
+	//         b["Parse"]
+	//     end
+	//     c["Store"]
+}
+
+// ExampleFlowchart_SubgraphEnd closes the subgraph opened last. Leaving one
+// open is reported from Build, because mermaid refuses a flowchart whose
+// subgraph never ends.
+func ExampleFlowchart_SubgraphEnd() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		Subgraph("outer", "Outer").
+		Subgraph("inner", "Inner").
+		NodeWithText("a", "A").
+		SubgraphEnd().
+		SubgraphEnd().
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     subgraph outer["Outer"]
+	//         subgraph inner["Inner"]
+	//             a["A"]
+	//         end
+	//     end
+}
+
+// ExampleFlowchart_SubgraphDirection lays one subgraph out across the page
+// while the chart around it runs down, which is the readable arrangement for a
+// row of steps inside a longer flow.
+func ExampleFlowchart_SubgraphDirection() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		Subgraph("ingest", "Ingest").
+		SubgraphDirection(flowchart.DirectionLR).
+		NodeWithText("a", "Fetch").
+		NodeWithText("b", "Parse").
+		LinkWithArrowHead("a", "b").
+		SubgraphEnd().
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     subgraph ingest["Ingest"]
+	//         direction LR
+	//         a["Fetch"]
+	//         b["Parse"]
+	//         a-->b
+	//     end
+}
+
+// ExampleDirection shows the four ways a subgraph can be laid out. The chart's
+// own direction is an option on NewFlowchart instead.
+func ExampleDirection() {
+	for _, direction := range []flowchart.Direction{
+		flowchart.DirectionTB,
+		flowchart.DirectionBT,
+		flowchart.DirectionLR,
+		flowchart.DirectionRL,
+	} {
+		_ = flowchart.NewFlowchart(os.Stdout).
+			Subgraph("g", "Group").
+			SubgraphDirection(direction).
+			SubgraphEnd().
+			Build()
+		fmt.Println()
+	}
+
+	// Output:
+	// flowchart TB
+	//     subgraph g["Group"]
+	//         direction TB
+	//     end
+	// flowchart TB
+	//     subgraph g["Group"]
+	//         direction BT
+	//     end
+	// flowchart TB
+	//     subgraph g["Group"]
+	//         direction LR
+	//     end
+	// flowchart TB
+	//     subgraph g["Group"]
+	//         direction RL
+	//     end
+}
+
+// ExampleFlowchart_Style colors one node outright. The style is mermaid's own
+// CSS-like syntax, written through unchanged.
+func ExampleFlowchart_Style() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("a", "Start").
+		Style("a", "fill:#f9f,stroke:#333").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     a["Start"]
+	//     style a fill:#f9f,stroke:#333
+}
+
+// ExampleFlowchart_ClassDef names a style so that several nodes can share it.
+func ExampleFlowchart_ClassDef() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		ClassDef("urgent", "fill:#f96,stroke:#333").
+		NodeWithText("a", "Start").
+		Class("a", "urgent").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     classDef urgent fill:#f96,stroke:#333
+	//     a["Start"]
+	//     class a urgent
+}
+
+// ExampleFlowchart_Class applies a named style to nodes. Several are given as
+// one comma separated list, which is what mermaid reads there.
+func ExampleFlowchart_Class() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		ClassDef("urgent", "fill:#f96").
+		NodeWithText("a", "Start").
+		NodeWithText("b", "End").
+		Class("a,b", "urgent").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     classDef urgent fill:#f96
+	//     a["Start"]
+	//     b["End"]
+	//     class a,b urgent
+}
+
+// ExampleFlowchart_ClickHref makes a node a link, with the text a browser shows
+// on hover. The tooltip is escaped the way a label is.
+func ExampleFlowchart_ClickHref() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("a", "Order").
+		ClickHref("a", "https://example.com/order", "The Order type").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     a["Order"]
+	//     click a "https://example.com/order" "The Order type"
+}
+
+// ExampleFlowchart_ClickCall makes a node call a function in the page when it
+// is clicked. The parentheses are added when the caller leaves them off.
+func ExampleFlowchart_ClickCall() {
+	_ = flowchart.NewFlowchart(os.Stdout).
+		NodeWithText("a", "Order").
+		ClickCall("a", "showOrder", "Show the order").
+		Build()
+
+	// Output:
+	// flowchart TB
+	//     a["Order"]
+	//     click a call showOrder() "Show the order"
+}

--- a/mermaid/flowchart/flowchart.go
+++ b/mermaid/flowchart/flowchart.go
@@ -25,7 +25,12 @@ type Flowchart struct {
 	err error
 	// config is the configuration for the flowchart.
 	config *config
+	// depth is how many subgraphs are open, counted in indentUnits.
+	depth int
 }
+
+// indentUnit is one level of subgraph nesting.
+const indentUnit = "    "
 
 // NewFlowchart returns a new Flowchart.
 func NewFlowchart(w io.Writer, opts ...Option) *Flowchart {
@@ -50,6 +55,23 @@ func NewFlowchart(w io.Writer, opts ...Option) *Flowchart {
 	}
 }
 
+// indent returns the prefix of a line at the current nesting.
+//
+// A flowchart with no subgraph in it indents by one unit, which is what every
+// line of every flowchart written before subgraphs existed used, so the output
+// of a chain that opens none is unchanged.
+func (f *Flowchart) indent() string {
+	return indentUnit + strings.Repeat(indentUnit, f.depth)
+}
+
+// setError records the first error and leaves any later one alone, because the
+// first is the one that explains the rest.
+func (f *Flowchart) setError(err error) {
+	if f.err == nil {
+		f.err = err
+	}
+}
+
 // String returns the flowchart body.
 func (f *Flowchart) String() string {
 	return strings.Join(f.body, internal.LineFeed())
@@ -69,7 +91,21 @@ func (f *Flowchart) Error() error {
 }
 
 // Build writes the flowchart body to the output destination.
+//
+// A subgraph left open is reported here rather than written out: mermaid
+// refuses a flowchart whose subgraph never ends, which loses the whole drawing.
+// So is any error the chain recorded, which is what every other builder in this
+// library does.
 func (f *Flowchart) Build() error {
+	if f.depth != 0 {
+		f.setError(fmt.Errorf("%d subgraph must be closed with SubgraphEnd before Build", f.depth))
+	}
+	// A recorded error stops the write, the way it does in every other builder
+	// here. Nothing recorded one before subgraphs existed, so no chain written
+	// against an earlier release reaches this.
+	if f.err != nil {
+		return f.err
+	}
 	if f.dest == nil {
 		if f.err == nil {
 			f.err = errors.New("output writer must not be nil")

--- a/mermaid/flowchart/flowchart_test.go
+++ b/mermaid/flowchart/flowchart_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/nao1215/markdown/internal"
 	"github.com/nao1215/markdown/internal/buildertest"
 	"github.com/nao1215/markdown/internal/golden"
 )
@@ -499,4 +500,169 @@ func TestErrorReportsTheRecordedError(t *testing.T) {
 	if f.Error() == nil || f.Error().Error() != fromBuild.Error() {
 		t.Errorf("Error() = %v, want the error Build returned, %v", f.Error(), fromBuild)
 	}
+}
+
+// TestSubgraphGroupsWhatFollowsIt covers the construct a flowchart of more than
+// a handful of nodes needs. Subgraphs nest, what they hold is indented, and the
+// title goes through the same escaping a node label does.
+func TestSubgraphGroupsWhatFollowsIt(t *testing.T) {
+	t.Parallel()
+
+	got := NewFlowchart(io.Discard).
+		Subgraph("ingest", `Ingest "raw"`).
+		SubgraphDirection(DirectionLR).
+		NodeWithText("a", "Fetch").
+		Subgraph("inner", "Retry").
+		NodeWithText("b", "Backoff").
+		SubgraphEnd().
+		SubgraphEnd().
+		NodeWithText("c", "Store").
+		String()
+
+	want := []string{
+		`    subgraph ingest["Ingest #quot;raw#quot;"]`,
+		`        direction LR`,
+		`        a["Fetch"]`,
+		`        subgraph inner["Retry"]`,
+		`            b["Backoff"]`,
+		`        end`,
+		`    end`,
+		`    c["Store"]`,
+	}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, w)
+		}
+	}
+}
+
+// TestAChartWithNoSubgraphIndentsAsItAlwaysDid pins that the indentation the
+// subgraphs brought does not move the output of a chain that opens none. Every
+// flowchart written before this existed has to come out byte for byte the same.
+func TestAChartWithNoSubgraphIndentsAsItAlwaysDid(t *testing.T) {
+	t.Parallel()
+
+	got := NewFlowchart(io.Discard).
+		NodeWithText("a", "Start").
+		NodeWithText("b", "End").
+		LinkWithArrowHead("a", "b").
+		String()
+
+	want := "flowchart TB" + internal.LineFeed() +
+		`    a["Start"]` + internal.LineFeed() +
+		`    b["End"]` + internal.LineFeed() +
+		"    a-->b"
+	if got != want {
+		t.Errorf("diagram =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// TestSubgraphErrorsAreRecordedRatherThanWritten covers the two ways a caller
+// can get the pairing wrong. An unclosed subgraph loses the whole diagram, so
+// neither is written out and hoped for.
+func TestSubgraphErrorsAreRecordedRatherThanWritten(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(io.Writer) *Flowchart
+		want  string
+	}{
+		"closing one that was never opened": {
+			build: func(w io.Writer) *Flowchart { return NewFlowchart(w).SubgraphEnd() },
+			want:  "SubgraphEnd was called outside a subgraph",
+		},
+		"setting a direction outside one": {
+			build: func(w io.Writer) *Flowchart {
+				return NewFlowchart(w).SubgraphDirection(DirectionLR)
+			},
+			want: "SubgraphDirection was called outside a subgraph",
+		},
+		"leaving one open": {
+			build: func(w io.Writer) *Flowchart {
+				return NewFlowchart(w).Subgraph("a", "A").NodeWithText("b", "B")
+			},
+			want: "1 subgraph must be closed with SubgraphEnd before Build",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.build(io.Discard).Build()
+			if err == nil {
+				t.Fatalf("Build() = nil, want an error mentioning %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("Build() = %v, want it to mention %q", err, tt.want)
+			}
+		})
+	}
+}
+
+// TestStylingWritesWhatMermaidReads covers the styling constructs the other
+// diagram builders in this library already had and this one did not.
+func TestStylingWritesWhatMermaidReads(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(*Flowchart) *Flowchart
+		want  string
+	}{
+		"style one node": {
+			build: func(f *Flowchart) *Flowchart { return f.Style("a", "fill:#f9f") },
+			want:  "    style a fill:#f9f",
+		},
+		"name a style": {
+			build: func(f *Flowchart) *Flowchart { return f.ClassDef("urgent", "fill:#f96") },
+			want:  "    classDef urgent fill:#f96",
+		},
+		"apply it to several nodes": {
+			build: func(f *Flowchart) *Flowchart { return f.Class("a,b", "urgent") },
+			want:  "    class a,b urgent",
+		},
+		"link a node": {
+			build: func(f *Flowchart) *Flowchart {
+				return f.ClickHref("a", "https://example.com", "Tooltip")
+			},
+			want: `    click a "https://example.com" "Tooltip"`,
+		},
+		"a tooltip is escaped like a label": {
+			build: func(f *Flowchart) *Flowchart {
+				return f.ClickHref("a", "https://example.com", `the "core"`)
+			},
+			want: `    click a "https://example.com" "the #quot;core#quot;"`,
+		},
+		"call a function": {
+			build: func(f *Flowchart) *Flowchart { return f.ClickCall("a", "showOrder", "Tooltip") },
+			want:  `    click a call showOrder() "Tooltip"`,
+		},
+		"a callback that already has its parentheses": {
+			build: func(f *Flowchart) *Flowchart { return f.ClickCall("a", "showOrder()", "Tooltip") },
+			want:  `    click a call showOrder() "Tooltip"`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.build(NewFlowchart(io.Discard)).String()
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("diagram =\n%s\nwant it to contain\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRecordedErrorContract asserts that an error the chain recorded surfaces
+// from Build, which is the contract every builder in this module shares. This
+// package could not record one until subgraphs arrived, so it did not run this
+// before.
+func TestRecordedErrorContract(t *testing.T) {
+	t.Parallel()
+
+	buildertest.RunRecordedErrorContract(t, func(w io.Writer) buildertest.Builder {
+		return NewFlowchart(w).SubgraphEnd()
+	})
 }

--- a/mermaid/flowchart/link.go
+++ b/mermaid/flowchart/link.go
@@ -4,54 +4,54 @@ import "fmt"
 
 // LinkWithArrowHead adds a link with an arrow head to the flowchart.
 func (f *Flowchart) LinkWithArrowHead(from, to string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s-->%s", from, to))
+	f.body = append(f.body, fmt.Sprintf("%s%s-->%s", f.indent(), from, to))
 	return f
 }
 
 // LinkWithArrowHeadAndText adds a link with an arrow head and text to the flowchart.
 func (f *Flowchart) LinkWithArrowHeadAndText(from, to, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s-->|\"%s\"|%s", from, escapeText(text), to))
+	f.body = append(f.body, fmt.Sprintf("%s%s-->|\"%s\"|%s", f.indent(), from, escapeText(text), to))
 	return f
 }
 
 // OpenLink adds an open link to the flowchart.
 func (f *Flowchart) OpenLink(from, to string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s --- %s", from, to))
+	f.body = append(f.body, fmt.Sprintf("%s%s --- %s", f.indent(), from, to))
 	return f
 }
 
 // OpenLinkWithText adds an open link with text to the flowchart.
 func (f *Flowchart) OpenLinkWithText(from, to, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s---|\"%s\"|%s", from, escapeText(text), to))
+	f.body = append(f.body, fmt.Sprintf("%s%s---|\"%s\"|%s", f.indent(), from, escapeText(text), to))
 	return f
 }
 
 // DottedLink adds a dotted link to the flowchart.
 func (f *Flowchart) DottedLink(from, to string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s-.->%s", from, to))
+	f.body = append(f.body, fmt.Sprintf("%s%s-.->%s", f.indent(), from, to))
 	return f
 }
 
 // DottedLinkWithText adds a dotted link with text to the flowchart.
 func (f *Flowchart) DottedLinkWithText(from, to, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s-. \"%s\" .-> %s", from, escapeText(text), to))
+	f.body = append(f.body, fmt.Sprintf("%s%s-. \"%s\" .-> %s", f.indent(), from, escapeText(text), to))
 	return f
 }
 
 // ThickLink adds a thick link to the flowchart.
 func (f *Flowchart) ThickLink(from, to string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s ==> %s", from, to))
+	f.body = append(f.body, fmt.Sprintf("%s%s ==> %s", f.indent(), from, to))
 	return f
 }
 
 // ThickLinkWithText adds a thick link with text to the flowchart.
 func (f *Flowchart) ThickLinkWithText(from, to, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s == \"%s\" ==> %s", from, escapeText(text), to))
+	f.body = append(f.body, fmt.Sprintf("%s%s == \"%s\" ==> %s", f.indent(), from, escapeText(text), to))
 	return f
 }
 
 // InvisibleLink adds an invisible link to the flowchart.
 func (f *Flowchart) InvisibleLink(from, to string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s ~~~ %s", from, to))
+	f.body = append(f.body, fmt.Sprintf("%s%s ~~~ %s", f.indent(), from, to))
 	return f
 }

--- a/mermaid/flowchart/node.go
+++ b/mermaid/flowchart/node.go
@@ -4,50 +4,50 @@ import "fmt"
 
 // Node adds a node to the flowchart.
 func (f *Flowchart) Node(name string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s", name))
+	f.body = append(f.body, fmt.Sprintf("%s%s", f.indent(), name))
 	return f
 }
 
 // NodeWithText adds a node with text to the flowchart.
 // Unicode characters are supported.
 func (f *Flowchart) NodeWithText(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\"%s\"]", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s[\"%s\"]", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // NodeWithMarkdown adds a node with markdown text to the flowchart.
 func (f *Flowchart) NodeWithMarkdown(name, markdownText string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\"`%s`\"]", name, escapeText(markdownText)))
+	f.body = append(f.body, fmt.Sprintf("%s%s[\"`%s`\"]", f.indent(), name, escapeText(markdownText)))
 	return f
 }
 
 // NodeWithNewLines adds a node with new lines to the flowchart.
 func (f *Flowchart) NodeWithNewLines(name, textWithNewLines string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\"`%s`\"]", name, escapeText(textWithNewLines)))
+	f.body = append(f.body, fmt.Sprintf("%s%s[\"`%s`\"]", f.indent(), name, escapeText(textWithNewLines)))
 	return f
 }
 
 // RoundEdgesNode adds a node with round edges to the flowchart.
 func (f *Flowchart) RoundEdgesNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s(\"%s\")", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s(\"%s\")", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // StadiumNode adds a node with stadium shape to the flowchart.
 func (f *Flowchart) StadiumNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s([\"%s\"])", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s([\"%s\"])", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // SubroutineNode adds a node with subroutine shape to the flowchart.
 func (f *Flowchart) SubroutineNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[[\"%s\"]]", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s[[\"%s\"]]", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // CylindricalNode adds a node with cylindrical shape to the flowchart.
 func (f *Flowchart) CylindricalNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[(\"%s\")]", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s[(\"%s\")]", f.indent(), name, escapeText(text)))
 	return f
 }
 
@@ -59,54 +59,54 @@ func (f *Flowchart) DatabaseNode(name, text string) *Flowchart {
 
 // CircleNode adds a node with circle shape to the flowchart.
 func (f *Flowchart) CircleNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s((\"%s\"))", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s((\"%s\"))", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // AsymmetricNode adds a node with asymmetric shape to the flowchart.
 func (f *Flowchart) AsymmetricNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s>\"%s\"]", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s>\"%s\"]", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // RhombusNode adds a node with rhombus shape to the flowchart.
 func (f *Flowchart) RhombusNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s{\"%s\"}", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s{\"%s\"}", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // HexagonNode adds a node with hexagon shape to the flowchart.
 func (f *Flowchart) HexagonNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s{{\"%s\"}}", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s{{\"%s\"}}", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // ParallelogramNode adds a node with parallelogram shape to the flowchart.
 func (f *Flowchart) ParallelogramNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[/\"%s\"/]", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s[/\"%s\"/]", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // ParallelogramAltNode adds a node with parallelogram shape to the flowchart.
 func (f *Flowchart) ParallelogramAltNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\\\"%s\"\\]", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s[\\\"%s\"\\]", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // TrapezoidNode adds a node with trapezoid shape to the flowchart.
 func (f *Flowchart) TrapezoidNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[/\"%s\"\\]", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s[/\"%s\"\\]", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // TrapezoidAltNode adds a node with trapezoid shape to the flowchart.
 func (f *Flowchart) TrapezoidAltNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s[\\\"%s\"/]", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s[\\\"%s\"/]", f.indent(), name, escapeText(text)))
 	return f
 }
 
 // DoubleCircleNode adds a node with double circle shape to the flowchart.
 func (f *Flowchart) DoubleCircleNode(name, text string) *Flowchart {
-	f.body = append(f.body, fmt.Sprintf("    %s(((\"%s\")))", name, escapeText(text)))
+	f.body = append(f.body, fmt.Sprintf("%s%s(((\"%s\")))", f.indent(), name, escapeText(text)))
 	return f
 }

--- a/mermaid/flowchart/style.go
+++ b/mermaid/flowchart/style.go
@@ -1,0 +1,77 @@
+package flowchart
+
+import "fmt"
+
+// Style colors one node outright.
+//
+// The style is mermaid's own CSS-like syntax, written through unchanged:
+// "fill:#f9f,stroke:#333,stroke-width:2px". It is not escaped, because it is
+// syntax rather than text; a caller putting a label in it is writing CSS, not a
+// label.
+func (f *Flowchart) Style(name, style string) *Flowchart {
+	if f.err != nil {
+		return f
+	}
+
+	f.body = append(f.body, fmt.Sprintf("%sstyle %s %s", f.indent(), name, style))
+	return f
+}
+
+// ClassDef names a style so that several nodes can share it, which is what
+// keeps a chart with a colored group from repeating itself.
+func (f *Flowchart) ClassDef(className, style string) *Flowchart {
+	if f.err != nil {
+		return f
+	}
+
+	f.body = append(f.body, fmt.Sprintf("%sclassDef %s %s", f.indent(), className, style))
+	return f
+}
+
+// Class applies a named style to nodes. Several nodes are given as one comma
+// separated list, which is what mermaid reads there.
+func (f *Flowchart) Class(names, className string) *Flowchart {
+	if f.err != nil {
+		return f
+	}
+
+	f.body = append(f.body, fmt.Sprintf("%sclass %s %s", f.indent(), names, className))
+	return f
+}
+
+// ClickHref makes a node a link, with the text a browser shows on hover.
+//
+// The tooltip is escaped the way a label is: it is text, and mermaid reads it
+// out of a quoted string the same way. The URL is written through unchanged.
+func (f *Flowchart) ClickHref(name, url, tooltip string) *Flowchart {
+	if f.err != nil {
+		return f
+	}
+
+	f.body = append(f.body,
+		fmt.Sprintf(`%sclick %s "%s" "%s"`, f.indent(), name, url, escapeText(tooltip)))
+	return f
+}
+
+// ClickCall makes a node call a function in the page when it is clicked.
+//
+// The callback is written as mermaid wants it, with the parentheses added when
+// the caller leaves them off, so that both "showOrder" and "showOrder()" reach
+// the drawing as a call.
+func (f *Flowchart) ClickCall(name, callback, tooltip string) *Flowchart {
+	if f.err != nil {
+		return f
+	}
+
+	f.body = append(f.body,
+		fmt.Sprintf(`%sclick %s call %s "%s"`, f.indent(), name, ensureCall(callback), escapeText(tooltip)))
+	return f
+}
+
+// ensureCall returns the callback with the parentheses mermaid expects.
+func ensureCall(callback string) string {
+	if len(callback) > 0 && callback[len(callback)-1] == ')' {
+		return callback
+	}
+	return callback + "()"
+}

--- a/mermaid/flowchart/subgraph.go
+++ b/mermaid/flowchart/subgraph.go
@@ -1,0 +1,84 @@
+package flowchart
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Subgraph opens a subgraph. Everything added until the matching SubgraphEnd is
+// drawn inside it.
+//
+// Subgraphs nest, and the pair is explicit rather than a callback taking a
+// nested builder: the chain stays flat, which is how every other builder in
+// this library reads, and how mermaid/c4 opens a boundary.
+//
+// The title is quoted and escaped the same way a node label is, so it can hold
+// whatever a label can. mermaid takes an unquoted title too, but only for the
+// titles that need no quoting, which is not something a caller should have to
+// think about.
+func (f *Flowchart) Subgraph(id, title string) *Flowchart {
+	if f.err != nil {
+		return f
+	}
+
+	f.body = append(f.body, fmt.Sprintf(`%ssubgraph %s["%s"]`, f.indent(), id, escapeText(title)))
+	f.depth++
+	return f
+}
+
+// SubgraphEnd closes the subgraph opened last.
+//
+// Calling it outside a subgraph is an error rather than a silent no-op: a chain
+// that has closed more subgraphs than it opened is not the diagram its author
+// meant, and the "end" it would write loses the whole drawing.
+func (f *Flowchart) SubgraphEnd() *Flowchart {
+	if f.err != nil {
+		return f
+	}
+	if f.depth == 0 {
+		f.setError(errors.New("SubgraphEnd was called outside a subgraph; there is nothing to close"))
+		return f
+	}
+
+	f.depth--
+	f.body = append(f.body, f.indent()+"end")
+	return f
+}
+
+// Direction is which way a subgraph is laid out.
+//
+// The flowchart's own direction is set with an option instead, WithOrientalTopDown
+// and its siblings, which is how this package has always spelled it. A subgraph
+// needs a value rather than an option, because it is set partway through a
+// chain, and the name matches what mermaid/state, mermaid/class and
+// mermaid/requirement call the same thing.
+type Direction string
+
+const (
+	// DirectionTB lays the subgraph out from the top to the bottom.
+	DirectionTB Direction = "TB"
+	// DirectionBT lays the subgraph out from the bottom to the top.
+	DirectionBT Direction = "BT"
+	// DirectionLR lays the subgraph out from the left to the right.
+	DirectionLR Direction = "LR"
+	// DirectionRL lays the subgraph out from the right to the left.
+	DirectionRL Direction = "RL"
+)
+
+// SubgraphDirection sets which way the subgraph opened last is laid out,
+// independently of the flowchart around it.
+//
+// It is the one thing a subgraph is for beyond grouping: a chart that runs top
+// to bottom can hold a row of steps that runs left to right.
+func (f *Flowchart) SubgraphDirection(direction Direction) *Flowchart {
+	if f.err != nil {
+		return f
+	}
+	if f.depth == 0 {
+		f.setError(errors.New("SubgraphDirection was called outside a subgraph"))
+		return f
+	}
+
+	f.body = append(f.body, fmt.Sprintf("%sdirection %s", f.indent(), direction))
+	return f
+}


### PR DESCRIPTION
Closes #180.

## Why

`mermaid/flowchart` built nodes and links and nothing else — thin for the diagram type people reach for first. Four constructs mermaid supports were unreachable, and three of them were already built for other diagram types in this repository:

| construct | was | elsewhere in this repo |
|---|---|---|
| `subgraph … end` | missing | grouping in `arch`, `c4`, `state`, `block` |
| `classDef` | missing | `block`, `class`, `requirement`, `quadrant` |
| `style` | missing | `block`, `class`, `requirement` |
| `click` | missing | `class` has `Link`/`Callback`/`ClickCall`/`ClickHref` |

A caller who needed a subgraph had to leave this library and write the mermaid by hand.

## What

- **`Subgraph` / `SubgraphEnd`** — the explicit pair `mermaid/c4` uses for boundaries, not a callback taking a nested builder, so the chain stays flat. They nest, and what they hold is indented.
- **`SubgraphDirection`** with an exported `Direction` type, matching what `mermaid/state`, `mermaid/class` and `mermaid/requirement` call the same thing. This is the reason to use a subgraph at all beyond grouping: a chart that runs top to bottom can hold a row of steps that runs left to right.
- **`ClassDef`, `Class`, `Style`, `ClickHref`, `ClickCall`** — signatures copied from `mermaid/class` and `mermaid/block` so the packages read alike.

## Measured, not assumed

A subgraph title and a click tooltip are **new positions** in the grammar, so I put the full punctuation probe set through both against the pinned mermaid rather than assuming a node label's rules carry over. They do, so both use the existing `escapeText`, and the edge-case document now exercises them.

## Output stability

A chart that opens no subgraph indents **exactly as it always did**. The indentation had to become depth-aware to nest, so `TestAChartWithNoSubgraphIndentsAsItAlwaysDid` pins the old output byte for byte. No golden file moves; the only committed sample that changes is the flowchart one, which now shows a subgraph so the render job draws one.

## One behavior change, and why it is safe

`Build` now returns an error the chain recorded, which every other builder here already did. `flowchart` could not: nothing in it recorded an error until `SubgraphEnd` could be called in the wrong place. Without this, half the new errors would surface from `Build` and half only from `Error`. No chain written against an earlier release can reach it, because no earlier call recorded anything. The package now runs `buildertest.RunRecordedErrorContract` like its siblings.

## Verification

- `go test ./...` and `go test -race` pass; `golangci-lint run ./...` reports 0 issues.
- `mermaid/flowchart` coverage 93.9%; every new symbol has a test and a godoc example (`TestEveryExportedSymbolHasAnExample` reports nothing missing).
- Every committed diagram renders: **64 blocks, 0 failed**, including the extended sample and the edge-case document.