### PR TITLE
docs(readme): fix the grammar in the opening sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # What is markdown package
 
-The markdown package is a simple markdown builder in golang. The markdown package assembles Markdown using method chaining, not uses a template engine like [html/template](https://pkg.go.dev/html/template). The syntax of Markdown follows GitHub Markdown.
+The markdown package is a simple Markdown builder in Go. It assembles Markdown using method chaining, and does not use a template engine like [html/template](https://pkg.go.dev/html/template). The syntax follows GitHub Markdown.
 
 It covers the GitHub Markdown syntax: headings, lists, checkbox lists, tables, code blocks, blockquotes, horizontal rules, text formatting, links, images, details, footnotes, math expressions, and alerts. It also builds 24 mermaid diagram types, from sequence and flowchart to Gantt, C4 context, and Wardley map; each one has an example below. Two helpers go beyond Markdown syntax: status badges and an index for a directory full of markdown files.
 


### PR DESCRIPTION
## Summary

The opening sentence of the README said "assembles Markdown using method chaining, not uses a template engine", which is not grammatical, and spelled the language "golang" and the format "markdown" inconsistently with the rest of the paragraph. This was raised in review on #185 but landed after that PR was merged, so it goes in separately.

## Changes

- Reworded the first paragraph of README.md: "does not use a template engine" instead of "not uses", "Go" instead of "golang", and "Markdown" capitalized consistently. Dropped the repeated "The markdown package" at the start of the second sentence.

## Design Decisions

Only the wording changes; the claims about the package are the same as before.