### PR TITLE
docs(readme): show the GitHub Actions job summary use case, verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ import (
 )
 
 func main() {
+	// Inside a step, append to the summary the runner renders; outside one,
+	// write a local file.
 	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	flags := os.O_APPEND | os.O_CREATE | os.O_WRONLY
 	if path == "" {
 		path = "generated.md"
+		flags = os.O_TRUNC | os.O_CREATE | os.O_WRONLY
 	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	f, err := os.OpenFile(path, flags, 0o600)
 	if err != nil {
 		panic(err)
 	}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,85 @@ Complex code that increases the complexity of the library, such as generating ne
 - OS: Linux, macOS, Windows
 - Go: 1.23 or later
 
+## Write GitHub Actions job summaries
+
+Inside a GitHub Actions step, the file named by `GITHUB_STEP_SUMMARY` is rendered on the run's summary page as GitHub Flavored Markdown, mermaid diagrams included. Hand that file to `NewMarkdown` and a Go tool in CI reports with tables, alerts, and charts instead of log lines:
+
+```go
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/nao1215/markdown"
+	"github.com/nao1215/markdown/mermaid/piechart"
+)
+
+func main() {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		path = "generated.md"
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	coverage := piechart.NewPieChart(
+		io.Discard,
+		piechart.WithTitle("Coverage"),
+		piechart.WithShowData(true),
+	).
+		LabelAndIntValue("covered", 92).
+		LabelAndIntValue("uncovered", 8).
+		String()
+
+	err = markdown.NewMarkdown(f, markdown.WithBlockSpacing()).
+		H2("Test Results").
+		Table(markdown.TableSet{
+			Header: []string{"Package", "Passed", "Failed"},
+			Rows: [][]string{
+				{"api", "120", "0"},
+				{"core", "89", "2"},
+			},
+		}).
+		Warning("2 tests failed in core; see the failed step for logs.").
+		CodeBlocks(markdown.SyntaxHighlightMermaid, coverage).
+		Build()
+
+	if err != nil {
+		panic(err)
+	}
+}
+```
+
+Plain text output: [markdown is here](./doc/actions-summary/generated.md)
+````text
+## Test Results
+
+| Package | Passed | Failed |
+|---------|---------|---------|
+| api | 120 | 0 |
+| core | 89 | 2 |
+
+> [!WARNING]  
+> 2 tests failed in core; see the failed step for logs.
+
+```mermaid
+%%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+pie showData
+    title Coverage
+    "covered" : 92
+    "uncovered" : 8
+```
+````
+
 ## Example
 ### Basic usage
 ```go

--- a/doc/actions-summary/generated.md
+++ b/doc/actions-summary/generated.md
@@ -1,0 +1,17 @@
+## Test Results
+
+| Package | Passed | Failed |
+|---------|---------|---------|
+| api | 120 | 0 |
+| core | 89 | 2 |
+
+> [!WARNING]  
+> 2 tests failed in core; see the failed step for logs.
+
+```mermaid
+%%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+pie showData
+    title Coverage
+    "covered" : 92
+    "uncovered" : 8
+```

--- a/doc/actions-summary/main.go
+++ b/doc/actions-summary/main.go
@@ -1,0 +1,63 @@
+//go:build linux || darwin
+
+// Package main is generating a GitHub Actions job summary.
+//
+// Inside a GitHub Actions step, GITHUB_STEP_SUMMARY names a file whose content
+// the run's summary page renders as GitHub Flavored Markdown, mermaid diagrams
+// included. This program appends to that file when the variable is set, so it
+// runs as a step unchanged; outside one it writes the committed sample.
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/nao1215/markdown"
+	"github.com/nao1215/markdown/mermaid/piechart"
+)
+
+//go:generate go run main.go
+
+func main() {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		path = "generated.md"
+	}
+	// The variable path is the point of this program: the Actions runner
+	// names the file the summary page renders, and this appends to it.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	coverage := piechart.NewPieChart(
+		io.Discard,
+		piechart.WithTitle("Coverage"),
+		piechart.WithShowData(true),
+	).
+		LabelAndIntValue("covered", 92).  //nolint:mnd
+		LabelAndIntValue("uncovered", 8). //nolint:mnd
+		String()
+
+	err = markdown.NewMarkdown(f, markdown.WithBlockSpacing()).
+		H2("Test Results").
+		Table(markdown.TableSet{
+			Header: []string{"Package", "Passed", "Failed"},
+			Rows: [][]string{
+				{"api", "120", "0"},
+				{"core", "89", "2"},
+			},
+		}).
+		Warning("2 tests failed in core; see the failed step for logs.").
+		CodeBlocks(markdown.SyntaxHighlightMermaid, coverage).
+		Build()
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/doc/actions-summary/main.go
+++ b/doc/actions-summary/main.go
@@ -18,14 +18,22 @@ import (
 
 //go:generate go run main.go
 
+// summaryFileMode keeps the summary file readable by its owner alone, which is
+// all the Actions runner needs.
+const summaryFileMode = 0o600
+
 func main() {
+	// The variable path is the point of this program: the Actions runner
+	// names the file the summary page renders. Appending is only right
+	// there, where earlier steps may already have written; regenerating the
+	// committed sample replaces it.
 	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	flags := os.O_APPEND | os.O_CREATE | os.O_WRONLY
 	if path == "" {
 		path = "generated.md"
+		flags = os.O_TRUNC | os.O_CREATE | os.O_WRONLY
 	}
-	// The variable path is the point of this program: the Actions runner
-	// names the file the summary page renders, and this appends to it.
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec
+	f, err := os.OpenFile(path, flags, summaryFileMode) // #nosec G304 G703 -- opening the file GITHUB_STEP_SUMMARY names is this program's purpose
 	if err != nil {
 		panic(err)
 	}

--- a/examples_test.go
+++ b/examples_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	md "github.com/nao1215/markdown"
+	"github.com/nao1215/markdown/mermaid/piechart"
 	"github.com/nao1215/markdown/mermaid/sequence"
 )
 
@@ -1351,4 +1352,51 @@ func ExampleIndex() {
 	// Output:
 	// ### guide
 	// - [Usage](usage.md)
+}
+
+// Example_gitHubActionsJobSummary writes the markdown a GitHub Actions job
+// summary is made of: inside a step, open the file named by the
+// GITHUB_STEP_SUMMARY environment variable for appending and hand it to
+// NewMarkdown in place of os.Stdout; the run's summary page renders the
+// result, mermaid diagrams included.
+func Example_gitHubActionsJobSummary() {
+	coverage := piechart.NewPieChart(
+		io.Discard,
+		piechart.WithTitle("Coverage"),
+		piechart.WithShowData(true),
+	).
+		LabelAndIntValue("covered", 92).
+		LabelAndIntValue("uncovered", 8).
+		String()
+
+	err := md.NewMarkdown(os.Stdout, md.WithBlockSpacing()).
+		H2("Test Results").
+		Table(md.TableSet{
+			Header: []string{"Package", "Passed", "Failed"},
+			Rows: [][]string{
+				{"api", "120", "0"},
+				{"core", "89", "2"},
+			},
+		}).
+		CodeBlocks(md.SyntaxHighlightMermaid, coverage).
+		Build()
+	if err != nil {
+		fmt.Println("build:", err)
+	}
+
+	// Output:
+	// ## Test Results
+	//
+	// | Package | Passed | Failed |
+	// |---------|---------|---------|
+	// | api | 120 | 0 |
+	// | core | 89 | 2 |
+	//
+	// ```mermaid
+	// %%{init: {"pie": {"textPosition": 0.75}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+	// pie showData
+	//     title Coverage
+	//     "covered" : 92
+	//     "uncovered" : 8
+	// ```
 }


### PR DESCRIPTION
## Summary

Inside a GitHub Actions step, the file named by GITHUB_STEP_SUMMARY is rendered on the run's summary page as GitHub Flavored Markdown, mermaid diagrams included — which is exactly what this library builds, and what several existing importers already use it for in CI. The README said nothing about it; now the use case sits near the top, with the same three verification layers every other README example has.

## Changes

- README.md: a "Write GitHub Actions job summaries" section between the intro and the examples, showing a complete program that appends a test-result table, a warning alert and a coverage pie chart to the summary file, followed by the output it produces.
- doc/actions-summary/main.go: the same program as a committed generator; it appends to GITHUB_STEP_SUMMARY when the variable is set, so it runs as an Actions step unchanged, and writes generated.md otherwise. The README block is pinned against that file by TestReadmeShowsWhatTheGeneratorsProduce, and the mermaid block in it is drawn by the real renderer in CI like every other committed diagram.
- examples_test.go: Example_gitHubActionsJobSummary, an output-verified godoc example of the same document (without the alert, whose trailing hard-break spaces a godoc Output block cannot hold — the quoted-print convention used by ExampleMarkdown_Warning covers that separately).

## Design Decisions

- The generator doubles as the real thing rather than being a mock: the only branch is where the output goes, so a reader can paste it into a workflow step as it is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for generating GitHub Actions job summaries in Markdown.
  * Included examples of test-result tables, warning alerts, Mermaid coverage charts, and fallback output.

* **Examples**
  * Added a complete example that reports test outcomes and coverage data.
  * Included a generated report showing passing and failing tests, a warning for failed tests, and 92% coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->