### PR TITLE
docs(readme): add Awesome Go badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 [![Go Reference](https://pkg.go.dev/badge/github.com/nao1215/markdown.svg)](https://pkg.go.dev/github.com/nao1215/markdown)
 [![MultiPlatformUnitTest](https://github.com/nao1215/markdown/actions/workflows/unit_test.yml/badge.svg)](https://github.com/nao1215/markdown/actions/workflows/unit_test.yml)
 [![reviewdog](https://github.com/nao1215/markdown/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/markdown/actions/workflows/reviewdog.yml)


### PR DESCRIPTION
## Why

The markdown package is now listed in [avelino/awesome-go](https://github.com/avelino/awesome-go). The listing is worth surfacing on the README the same way gup does.

## What

- Add the `Mentioned in Awesome Go` badge to the README badge block, right after the all-contributors badge — the same position gup uses.

## Note

No functional change; README only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Awesome Go badge linking to the project’s entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->