### PR TITLE
chore: maintenance sweep - action bumps, Go range CI, honest 1.23 floor

### DIFF
--- a/.github/workflows/api_compatibility.yml
+++ b/.github/workflows/api_compatibility.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.25"
+          go-version: "stable"
 
       - name: Install apidiff
         run: go install golang.org/x/exp/cmd/apidiff@${EXP_TOOLS_VERSION}
@@ -131,7 +131,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.25"
+          go-version: "stable"
 
       - name: Install gorelease
         run: go install golang.org/x/exp/cmd/gorelease@${EXP_TOOLS_VERSION}

--- a/.github/workflows/check_generate_file.yml
+++ b/.github/workflows/check_generate_file.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: "go.mod"
+          go-version: "stable"
           cache-dependency-path: "go.sum"
 
       - name: go mod tidy leaves the tree clean

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1"
+          go-version: "stable"
           check-latest: true
 
       # doc/ holds 22 sample programs whose main() is never called by a test.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: "go.mod"
+          go-version: "stable"
 
       - name: Fuzz ${{ matrix.target }}
         run: go test -run='^$' -fuzz='^${{ matrix.target }}$' -fuzztime=3m .

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: "go.mod"
+          go-version: "stable"
 
       - name: Run golangci-lint as an enforced gate
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,7 +29,11 @@ jobs:
         with:
           go-version: "stable"
 
+      # The pin has to keep up with the Go above it: golangci-lint type-checks
+      # the standard library it is pointed at, and v2.12.2 cannot parse Go
+      # 1.27's (generic methods), so it fails on the toolchain rather than on
+      # this repository's code.
       - name: Run golangci-lint as an enforced gate
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: v2.13.2

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@2eb4727ebc7504944ddbcdd2f7157db492026c3f # master as of 2026-08-11
+        uses: securego/gosec@deb54465fea23d19a77f037e11e6589021f8501d # master as of 2026-08-29
         with:
           args: --exclude-dir=examples --exclude-dir=aws ./...

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: reviewdog/action-actionlint@d63ba7532e0942965320cd8d73cbae4c7b3c5283 # v1
+      - uses: reviewdog/action-actionlint@008e91ff5c4d4ef257daf87cfab9713486270787 # v1.73.2
         with:
           reporter: github-pr-review
           level: warning

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,10 +20,17 @@ jobs:
           - "ubuntu-latest"
           - "windows-latest"
           - "macos-latest"
+        # The floor go.mod declares and the newest release. markdown is a
+        # library most of the other repositories depend on, so the 1.23 floor is
+        # the promise that matters and this is the only place it is checked.
+        # "stable" tracks each Go release without an edit -- and it is not "1",
+        # because setup-go resolves "1" from its own manifest, which lags a
+        # fresh release and would leave the ceiling quietly behind. The
+        # intermediate releases were dropped: with nine jobs already, they cost
+        # more than they catch between a verified floor and a verified ceiling.
         go:
           - "1.23"
-          - "1.24"
-          - "1.25"
+          - "stable"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/nao1215/markdown
 
 go 1.23
 
-toolchain go1.24.0
-
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/karrick/godirwalk v1.17.0


### PR DESCRIPTION
## Summary

Routine maintenance sweep. It takes the two open Dependabot action bumps, fixes a matrix ceiling that had fallen two Go releases behind, and removes a `toolchain` directive that quietly contradicted the declared floor.

Deliberately, no Go module dependencies are updated here. See Design Decisions.

## Changes

- `go.mod`: the `toolchain go1.24.0` line is removed. The `go 1.23` directive is unchanged.
- `.github/workflows/unit_test.yml`: the matrix goes from `["1.23", "1.24", "1.25"]` to `["1.23", "stable"]`.
- `.github/workflows/{fuzz,golangci-lint,check_generate_file}.yml`: `go-version-file: "go.mod"` becomes `go-version: "stable"`.
- `.github/workflows/coverage.yml`: `go-version: "1"` becomes `"stable"`.
- `.github/workflows/api_compatibility.yml`: `go-version: "1.25"` becomes `"stable"`.
- `.github/workflows/gosec.yml`: `securego/gosec` moves to `deb54465...`.
- `.github/workflows/reviewdog.yml`: `reviewdog/action-actionlint` moves to `008e91ff...` (v1.73.2).

## Design Decisions

No module updates, on purpose. Every direct dependency is already at its newest version -- `go-cmp`, `godirwalk`, `tablewriter`, `goldmark` and `yaml.v3` all have nothing newer. The only updates `go get -u ./...` finds are indirect, and two of them (`github.com/fatih/color` v1.19.0 and `golang.org/x/sys` v0.47.0) declare `go 1.25`, which raises this module's directive from 1.23 to 1.25. markdown is the library most of the other repositories here depend on, so its floor is a promise made to all of them; trading two Go releases' worth of audience for indirect updates that fix nothing observable is the wrong trade. They will come in for free the next time a direct dependency requires them.

The `toolchain go1.24.0` line was doing the opposite of what the `go 1.23` line says. Declaring a 1.23 floor and then requiring a 1.24 toolchain means a user on Go 1.23 does not get a clear "this module needs a newer Go" -- they get a silent toolchain download instead, or a failure if that is disabled. With the line gone, the floor is what go.mod says it is, and the unit-test matrix proves it: the tree builds, vets and tests at language version 1.23.

The matrix ceiling was pinned to `"1.25"`, which stopped being the newest Go two releases ago, so the leg meant to catch new vet checks and runtime changes was testing something old. `"stable"` tracks each release without an edit. It is deliberately not `"1"`: setup-go resolves `"1"` from its own version manifest, which lags a fresh Go release, so `"1"` would go stale the same way.

The intermediate 1.24 and 1.25 legs were dropped rather than kept alongside `stable`. The matrix is already nine jobs across three operating systems, and between a floor that is verified and a ceiling that is verified, the versions in between have not been where breakage shows up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use the latest stable Go release.
  * Simplified compatibility testing to cover the minimum supported Go version and the current stable release.
  * Updated security scanning and workflow linting tools.
  * Removed the repository’s toolchain-specific Go version requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->